### PR TITLE
Implement RBAC handling for clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d
-	k8s.io/kubectl v0.0.0
 	sigs.k8s.io/controller-runtime v0.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,7 @@ github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMX
 github.com/containerd/containerd v1.3.0-beta.2.0.20190823190603-4a2f61c4f2b4/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.3.0 h1:xjvXQWABwS2uiv3TWgQt5Uth60Gu86LTGZXMJkjc7rY=
 github.com/containerd/containerd v1.3.0/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 h1:4BX8f882bXEDKfWIf0wa8HRvpnBoPszJJXL+TVbBw4M=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/typeurl v0.0.0-20190228175220-2a93cfde8c20/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=

--- a/pkg/controller/cluster/cluster_rbac.go
+++ b/pkg/controller/cluster/cluster_rbac.go
@@ -1,0 +1,48 @@
+package cluster
+
+import (
+	"context"
+
+	synv1alpha1 "github.com/projectsyn/lieutenant-operator/pkg/apis/syn/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (r *ReconcileCluster) createClusterRBAC(cluster synv1alpha1.Cluster) error {
+	objMeta := metav1.ObjectMeta{
+		Name:            cluster.Name,
+		Namespace:       cluster.Namespace,
+		OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&cluster, synv1alpha1.SchemeBuilder.GroupVersion.WithKind("Cluster"))},
+	}
+	serviceAccount := &corev1.ServiceAccount{ObjectMeta: objMeta}
+	role := &rbacv1.Role{
+		ObjectMeta: objMeta,
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups:     []string{synv1alpha1.SchemeGroupVersion.Group},
+			Resources:     []string{"clusters"},
+			Verbs:         []string{"get", "update"},
+			ResourceNames: []string{cluster.Name},
+		}},
+	}
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: objMeta,
+		RoleRef: rbacv1.RoleRef{
+			Kind: "Role",
+			Name: role.Name,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      serviceAccount.Name,
+			Namespace: serviceAccount.Namespace,
+		}},
+	}
+	for _, item := range []runtime.Object{serviceAccount, role, roleBinding} {
+		if err := r.client.Create(context.TODO(), item); err != nil && !errors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/cluster/cluster_reconcile.go
+++ b/pkg/controller/cluster/cluster_reconcile.go
@@ -35,6 +35,10 @@ func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
+	if err := r.createClusterRBAC(*instance); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	if instance.Status.BootstrapToken == nil {
 		reqLogger.Info("Adding status to Cluster object")
 		err := r.newStatus(instance)


### PR DESCRIPTION
Create a ServiceAccount, Role and RoleBinding for new clusters to allow
steward to manage (get, update) it's own cluster object.

Signed-off-by: Simon Rüegg <simon.ruegg@vshn.ch>