### PR TITLE
Implement GitRepo type

### DIFF
--- a/deploy/crds/syn.tools_clusters_crd.yaml
+++ b/deploy/crds/syn.tools_clusters_crd.yaml
@@ -89,6 +89,15 @@ spec:
                 repoName:
                   description: RepoName ame of Git repository
                   type: string
+                repoType:
+                  default: auto
+                  description: RepoType specifies if a repo should be managed by the
+                    git controller. A value of 'unmanaged' means it's not manged by
+                    the controller
+                  enum:
+                  - auto
+                  - unmanaged
+                  type: string
               required:
               - apiSecretRef
               - path

--- a/deploy/crds/syn.tools_gitrepos_crd.yaml
+++ b/deploy/crds/syn.tools_gitrepos_crd.yaml
@@ -74,6 +74,14 @@ spec:
             repoName:
               description: RepoName ame of Git repository
               type: string
+            repoType:
+              default: auto
+              description: RepoType specifies if a repo should be managed by the git
+                controller. A value of 'unmanaged' means it's not manged by the controller
+              enum:
+              - auto
+              - unmanaged
+              type: string
             tenantRef:
               description: TenantRef references the tenant this repo belongs to
               properties:

--- a/deploy/crds/syn.tools_tenants_crd.yaml
+++ b/deploy/crds/syn.tools_tenants_crd.yaml
@@ -78,6 +78,15 @@ spec:
                 repoName:
                   description: RepoName ame of Git repository
                   type: string
+                repoType:
+                  default: auto
+                  description: RepoType specifies if a repo should be managed by the
+                    git controller. A value of 'unmanaged' means it's not manged by
+                    the controller
+                  enum:
+                  - auto
+                  - unmanaged
+                  type: string
               required:
               - apiSecretRef
               - path

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,8 @@ github.com/operator-framework/operator-registry v1.5.3 h1:az83WDwgB+tHsmVn+tFq72
 github.com/operator-framework/operator-registry v1.5.3/go.mod h1:agrQlkWOo1q8U1SAaLSS2WQ+Z9vswNT2M2HFib9iuLY=
 github.com/operator-framework/operator-registry v1.5.7-0.20200121213444-d8e2ec52c19a h1:+Kxyr2Vp1PaPAF2yzrxLu0NcxbX9O5W+mHP6w+wQ5w8=
 github.com/operator-framework/operator-registry v1.5.7-0.20200121213444-d8e2ec52c19a/go.mod h1:ekexcV4O8YMxdQuPb+Xco7MHfVmRIq7Jvj5e6NU7dHI=
-github.com/operator-framework/operator-sdk v0.15.1 h1:MSyez9UD47UtA0voGYotk/8i64Km7fZyfgwGRlhOvqY=
-github.com/operator-framework/operator-sdk v0.15.1/go.mod h1:RkC5LpluVONa08ORFIIVCYrEr855xG1/NltRL2jQ8qo=
+github.com/operator-framework/operator-sdk v0.15.2 h1:VlxI0J+HLmMKs5k53drQ/B1AXhyNj0OaD2BbREt8Hnk=
+github.com/operator-framework/operator-sdk v0.15.2/go.mod h1:RkC5LpluVONa08ORFIIVCYrEr855xG1/NltRL2jQ8qo=
 github.com/otiai10/copy v1.0.1/go.mod h1:8bMCJrAqOtN/d9oyh5HR7HhLQMvcGMpGdwRDYsfOCHc=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776/go.mod h1:3HNVkVOU7vZeFXocWuvtcS0XSFLcf2XUSDHkq9t1jU4=
@@ -722,6 +722,8 @@ github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmF
 github.com/vmware/govmomi v0.20.1/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/xanzy/go-gitlab v0.15.0 h1:rWtwKTgEnXyNUGrOArN7yyc3THRkpYcKXIXia9abywQ=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
+github.com/xanzy/go-gitlab v0.25.0 h1:G5aTZeqZd66Q6qMVieBfmHBsPpF0jY92zCLAMpULe3I=
+github.com/xanzy/go-gitlab v0.25.0/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=

--- a/pkg/apis/syn/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/syn/v1alpha1/gitrepo_types.go
@@ -13,6 +13,15 @@ const (
 	TypeUnknown = GitType("")
 )
 
+const (
+	// AutoRepoType managed by the git controller
+	AutoRepoType = RepoType("auto")
+	// UnmanagedRepoType by the git controller. These objects are only used as data store
+	UnmanagedRepoType = RepoType("unmanaged")
+	// DefaultRepoType is auto
+	DefaultRepoType = RepoType("")
+)
+
 // GitPhase enum values
 const (
 	Created      = GitPhase("created")
@@ -25,6 +34,9 @@ type GitPhase string
 
 // GitType as the enum for git types
 type GitType string
+
+// RepoType specifies the type of the repo
+type RepoType string
 
 // GitRepoSpec defines the desired state of GitRepo
 type GitRepoSpec struct {
@@ -44,6 +56,10 @@ type GitRepoTemplate struct {
 	Path string `json:"path"`
 	// RepoName ame of Git repository
 	RepoName string `json:"repoName"`
+	// RepoType specifies if a repo should be managed by the git controller. A value of 'unmanaged' means it's not manged by the controller
+	// +kubebuilder:default=auto
+	// +kubebuilder:validation:Enum=auto;unmanaged
+	RepoType RepoType `json:"repoType,omitempty"`
 }
 
 // DeployKey defines an SSH key to be used for git operations.

--- a/pkg/controller/gitrepo/gitrepo_reconcile.go
+++ b/pkg/controller/gitrepo/gitrepo_reconcile.go
@@ -42,6 +42,9 @@ func (r *ReconcileGitRepo) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 	helpers.AddTenantLabel(&instance.ObjectMeta, instance.Spec.TenantRef.Name)
+	if instance.Spec.RepoType == synv1alpha1.DefaultRepoType {
+		instance.Spec.RepoType = synv1alpha1.AutoRepoType
+	}
 	secret := &corev1.Secret{}
 	namespacedName := types.NamespacedName{
 		Name:      instance.Spec.APISecretRef.Name,

--- a/pkg/controller/gitrepo/gitrepo_reconcile_test.go
+++ b/pkg/controller/gitrepo/gitrepo_reconcile_test.go
@@ -126,6 +126,7 @@ func TestReconcileGitRepo_Reconcile(t *testing.T) {
 				err = cl.Get(context.TODO(), req.NamespacedName, gitRepo)
 				assert.NoError(t, err)
 				assert.Equal(t, string(secret.Data[SecretHostKeysName]), gitRepo.Status.HostKeys)
+				assert.Equal(t, synv1alpha1.AutoRepoType, gitRepo.Spec.RepoType)
 			}
 		})
 	}

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "config:base"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
This value specifies if a GitRepo object is actually handled by the git
controller. A value of `unmanaged` means the controller won't manage it
and it's sole purpose is data storage. An empty value defaults to `auto`
which means it's managed by the controller.

Signed-off-by: Simon Rüegg <simon.ruegg@vshn.ch>