### PR TITLE
Fix key compare with whitespaces and gitrepourl not populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Key comparison issues when using multiline strings in YAML
+- GitRepoURL not being set for clusters/tenants
 
 ## v0.0.4 - 2020-02-17
 ### Added

--- a/pkg/controller/cluster/cluster_reconcile.go
+++ b/pkg/controller/cluster/cluster_reconcile.go
@@ -60,6 +60,10 @@ func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	helpers.AddTenantLabel(&instance.ObjectMeta, instance.Spec.TenantRef.Name)
+	instance.Spec.GitRepoURL, err = helpers.GetGitRepoURL(instance, r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 	err = r.client.Status().Update(context.TODO(), instance)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/tenant/tenant_reconcile.go
+++ b/pkg/controller/tenant/tenant_reconcile.go
@@ -41,5 +41,9 @@ func (r *ReconcileTenant) Reconcile(request reconcile.Request) (reconcile.Result
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	instance.Spec.GitRepoURL, err = helpers.GetGitRepoURL(instance, r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 	return reconcile.Result{}, r.client.Update(context.TODO(), instance)
 }

--- a/pkg/git/helpers/helpers.go
+++ b/pkg/git/helpers/helpers.go
@@ -3,6 +3,7 @@ package helpers
 
 import (
 	"reflect"
+	"strings"
 
 	synv1alpha1 "github.com/projectsyn/lieutenant-operator/pkg/apis/syn/v1alpha1"
 )
@@ -15,9 +16,16 @@ import (
 func CompareKeys(keySetA, keySetB map[string]synv1alpha1.DeployKey) map[string]synv1alpha1.DeployKey {
 	deltaKeys := make(map[string]synv1alpha1.DeployKey)
 	for k, v := range keySetA {
-		if !reflect.DeepEqual(keySetB[k], v) {
+		if !reflect.DeepEqual(trimKey(keySetB[k]), trimKey(v)) {
 			deltaKeys[k] = v
 		}
 	}
 	return deltaKeys
+}
+
+// trimKey returns a given deploy key without any leading or trailing whitespaces.
+// This avoids issues with multiline strings in YAML
+func trimKey(key synv1alpha1.DeployKey) synv1alpha1.DeployKey {
+	key.Key = strings.TrimSpace(key.Key)
+	return key
 }

--- a/pkg/helpers/crd.go
+++ b/pkg/helpers/crd.go
@@ -71,3 +71,17 @@ func AddTenantLabel(meta *metav1.ObjectMeta, tenant string) {
 	}
 	meta.Labels[apis.LabelNameTenant] = tenant
 }
+
+func GetGitRepoURL(obj metav1.Object, client client.Client) (string, error) {
+	gitRepo := &synv1alpha1.GitRepo{}
+	repoNamespacedName := types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+	err := client.Get(context.TODO(), repoNamespacedName, gitRepo)
+	if err != nil {
+		return "", err
+	}
+
+	return gitRepo.Status.URL, nil
+}


### PR DESCRIPTION
This merge request fixes issues with:
* key comparison not working when using multiline strings in YAML
* gitrepourl not populated for tenants and clusters