### PR TITLE
Implement git file templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Docs from the SDD
 - Doc generator from CRDs
+- GitRepo file templates
+- Add an empty file for each cluster to the tenant git repo
 
 ## v0.0.5 - 2020-02-27
 ### Fixed

--- a/deploy/crds/syn.tools_clusters_crd.yaml
+++ b/deploy/crds/syn.tools_clusters_crd.yaml
@@ -101,10 +101,12 @@ spec:
                   - auto
                   - unmanaged
                   type: string
-              required:
-              - apiSecretRef
-              - path
-              - repoName
+                templateFiles:
+                  additionalProperties:
+                    type: string
+                  description: TemplateFiles is a list of files that should be pushed
+                    to the repository after its creation.
+                  type: object
               type: object
             gitRepoURL:
               description: GitRepoURL git repository storing the cluster configuration

--- a/deploy/crds/syn.tools_clusters_crd.yaml
+++ b/deploy/crds/syn.tools_clusters_crd.yaml
@@ -91,7 +91,7 @@ spec:
                   description: Path to Git repository
                   type: string
                 repoName:
-                  description: RepoName ame of Git repository
+                  description: RepoName name of Git repository
                   type: string
                 repoType:
                   description: RepoType specifies if a repo should be managed by the

--- a/deploy/crds/syn.tools_gitrepos_crd.yaml
+++ b/deploy/crds/syn.tools_gitrepos_crd.yaml
@@ -76,7 +76,7 @@ spec:
               description: Path to Git repository
               type: string
             repoName:
-              description: RepoName ame of Git repository
+              description: RepoName name of Git repository
               type: string
             repoType:
               description: RepoType specifies if a repo should be managed by the git

--- a/deploy/crds/syn.tools_gitrepos_crd.yaml
+++ b/deploy/crds/syn.tools_gitrepos_crd.yaml
@@ -85,6 +85,12 @@ spec:
               - auto
               - unmanaged
               type: string
+            templateFiles:
+              additionalProperties:
+                type: string
+              description: TemplateFiles is a list of files that should be pushed
+                to the repository after its creation.
+              type: object
             tenantRef:
               description: TenantRef references the tenant this repo belongs to
               properties:
@@ -94,9 +100,6 @@ spec:
                   type: string
               type: object
           required:
-          - apiSecretRef
-          - path
-          - repoName
           - tenantRef
           type: object
         status:

--- a/deploy/crds/syn.tools_tenants_crd.yaml
+++ b/deploy/crds/syn.tools_tenants_crd.yaml
@@ -80,7 +80,7 @@ spec:
                   description: Path to Git repository
                   type: string
                 repoName:
-                  description: RepoName ame of Git repository
+                  description: RepoName name of Git repository
                   type: string
                 repoType:
                   description: RepoType specifies if a repo should be managed by the

--- a/deploy/crds/syn.tools_tenants_crd.yaml
+++ b/deploy/crds/syn.tools_tenants_crd.yaml
@@ -90,10 +90,12 @@ spec:
                   - auto
                   - unmanaged
                   type: string
-              required:
-              - apiSecretRef
-              - path
-              - repoName
+                templateFiles:
+                  additionalProperties:
+                    type: string
+                  description: TemplateFiles is a list of files that should be pushed
+                    to the repository after its creation.
+                  type: object
               type: object
             gitRepoURL:
               description: GitRepoURL git repository storing the tenant configuration.

--- a/docs/modules/ROOT/partials/crds.html
+++ b/docs/modules/ROOT/partials/crds.html
@@ -830,7 +830,7 @@ string
 </td>
 <td class="tableblock halign-left valign-top">
 <p class="tableblock">
-<p>RepoName ame of Git repository</p>
+<p>RepoName name of Git repository</p>
 <p class="tableblock">
 </td>
 </tr>
@@ -848,6 +848,22 @@ RepoType
 <td class="tableblock halign-left valign-top">
 <p class="tableblock">
 <p>RepoType specifies if a repo should be managed by the git controller. A value of &lsquo;unmanaged&rsquo; means it&rsquo;s not manged by the controller</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<code>templateFiles</code></br>
+<em>
+map[string]string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>TemplateFiles is a list of files that should be pushed to the repository
+after its creation.</p>
 <p class="tableblock">
 </td>
 </tr>
@@ -1065,5 +1081,5 @@ GitRepoTemplate
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>5ffda85</code>.
+on git commit <code>a8f4adf</code>.
 </em></p>

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -6,7 +6,7 @@ spec:
   displayName: Big Corp. Production Cluster
   gitRepoTemplate:
     path: cluster
-    repoName: test
+    repoName: cluster1
     apiSecretRef:
       name: example-secret
       namespace: syn-lieutenant

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: syn.tools/v1alpha1
 kind: Cluster
 metadata:
-  name: ae3oso
+  name: c-ae3oso
 spec:
   displayName: Big Corp. Production Cluster
   gitRepoTemplate:
@@ -16,7 +16,7 @@ spec:
         key: AAAAC3NzaC1lZDI1NTE5AAAAIJ22mHNYfSPnLAj8YiKa0RmxafD9r5nEUquizay7xh3s
         writeAccess: true
   tenantRef:
-    name: aezoo6
+    name: t-aezoo6
   tokenLifeTime: 4h
   facts:
     distribution: openshift3

--- a/examples/gitrepo-secret.yaml
+++ b/examples/gitrepo-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 stringData:
-  endpoint: http://10.144.1.190:8080
-  token: T9xR6YyStXwkFbJFKMyU
+  endpoint: http://192.168.5.42:8080
+  token: zbxUWoPykEh5ZjG-mFsa
 kind: Secret
 metadata:
   name: example-secret

--- a/examples/gitrepo.yaml
+++ b/examples/gitrepo.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   tenantRef:
     name: blubb
+    namespace: syn-lieutenant
   apiSecretRef:
     name: example-secret
   path: cluster/subgroup

--- a/examples/tenant.yaml
+++ b/examples/tenant.yaml
@@ -6,7 +6,7 @@ spec:
   displayName: Big Corp.
   gitRepoTemplate:
     path: tenant
-    repoName: test
+    repoName: tenant1
     apiSecretRef:
       name: example-secret
       namespace: syn-lieutenant

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/projectsyn/lieutenant-operator
 go 1.13
 
 require (
-	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0 // indirect
+	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/go-logr/logr v0.1.0
 	github.com/icza/gox v0.0.0-20200320174535-a6ff52ab3d90
 	github.com/operator-framework/operator-sdk v0.16.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0 // indirect
 	github.com/go-logr/logr v0.1.0
+	github.com/icza/gox v0.0.0-20200320174535-a6ff52ab3d90
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -431,6 +431,8 @@ github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365 h1:ECW73yc9MY7935nNYXUkK7Dz17YuSUI9yqRqYS8aBww=
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
+github.com/icza/gox v0.0.0-20200320174535-a6ff52ab3d90 h1:RNoA3SlUrqLdl6c5elZ1R9DwI4Bln8mLWoQGooSCytw=
+github.com/icza/gox v0.0.0-20200320174535-a6ff52ab3d90/go.mod h1:VbcN86fRkkUMPX2ufM85Um8zFndLZswoIW1eYtpAcVk=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/pkg/apis/syn/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/syn/v1alpha1/gitrepo_types.go
@@ -54,7 +54,7 @@ type GitRepoTemplate struct {
 	DeployKeys map[string]DeployKey `json:"deployKeys,omitempty"`
 	// Path to Git repository
 	Path string `json:"path,omitempty"`
-	// RepoName ame of Git repository
+	// RepoName name of Git repository
 	RepoName string `json:"repoName,omitempty"`
 	// RepoType specifies if a repo should be managed by the git controller. A value of 'unmanaged' means it's not manged by the controller
 	// +kubebuilder:validation:Enum=auto;unmanaged

--- a/pkg/apis/syn/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/syn/v1alpha1/gitrepo_types.go
@@ -49,16 +49,19 @@ type GitRepoSpec struct {
 // controller creating the template instance.
 type GitRepoTemplate struct {
 	// APISecretRef reference to secret containing connection information
-	APISecretRef corev1.SecretReference `json:"apiSecretRef"`
+	APISecretRef corev1.SecretReference `json:"apiSecretRef,omitempty"`
 	// DeployKeys optional list of SSH deploy keys. If not set, not deploy keys will be configured
 	DeployKeys map[string]DeployKey `json:"deployKeys,omitempty"`
 	// Path to Git repository
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 	// RepoName ame of Git repository
-	RepoName string `json:"repoName"`
+	RepoName string `json:"repoName,omitempty"`
 	// RepoType specifies if a repo should be managed by the git controller. A value of 'unmanaged' means it's not manged by the controller
 	// +kubebuilder:validation:Enum=auto;unmanaged
 	RepoType RepoType `json:"repoType,omitempty"`
+	// TemplateFiles is a list of files that should be pushed to the repository
+	// after its creation.
+	TemplateFiles map[string]string `json:"templateFiles,omitempty"`
 }
 
 // DeployKey defines an SSH key to be used for git operations.

--- a/pkg/apis/syn/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/syn/v1alpha1/zz_generated.deepcopy.go
@@ -289,6 +289,13 @@ func (in *GitRepoTemplate) DeepCopyInto(out *GitRepoTemplate) {
 			(*out)[key] = val
 		}
 	}
+	if in.TemplateFiles != nil {
+		in, out := &in.TemplateFiles, &out.TemplateFiles
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controller/cluster/cluster_reconcile.go
+++ b/pkg/controller/cluster/cluster_reconcile.go
@@ -140,5 +140,5 @@ func (r *ReconcileCluster) updateTenantGitRepo(tenant types.NamespacedName, file
 		return r.client.Update(context.TODO(), tenantCR)
 	}
 
-	return r.client.Update(context.TODO(), tenantCR)
+	return nil
 }

--- a/pkg/controller/cluster/cluster_reconcile.go
+++ b/pkg/controller/cluster/cluster_reconcile.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -56,6 +57,14 @@ func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Resul
 	err = helpers.CreateOrUpdateGitRepo(instance, gvk, instance.Spec.GitRepoTemplate, r.client, instance.Spec.TenantRef)
 	if err != nil {
 		reqLogger.Error(err, "Cannot create or update git repo object")
+		return reconcile.Result{}, err
+	}
+
+	repoName := request.NamespacedName
+	repoName.Name = instance.Spec.TenantRef.Name
+
+	err = r.updateTenantGitRepo(repoName, instance.GetName()+".yml")
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -108,4 +117,28 @@ func (r *ReconcileCluster) newStatus(cluster *synv1alpha1.Cluster) error {
 	return nil
 }
 
-//TODO: update git if template changes
+func (r *ReconcileCluster) updateTenantGitRepo(tenant types.NamespacedName, filename string) error {
+	tenantCR := &synv1alpha1.Tenant{}
+
+	err := r.client.Get(context.TODO(), tenant, tenantCR)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		} else {
+			return nil
+		}
+	}
+
+	if tenantCR.Spec.GitRepoTemplate.TemplateFiles == nil {
+		tenantCR.Spec.GitRepoTemplate.TemplateFiles = map[string]string{}
+	}
+
+	if _, ok := tenantCR.Spec.GitRepoTemplate.TemplateFiles[filename]; !ok {
+
+		tenantCR.Spec.GitRepoTemplate.TemplateFiles[filename] = ""
+
+		return r.client.Update(context.TODO(), tenantCR)
+	}
+
+	return r.client.Update(context.TODO(), tenantCR)
+}

--- a/pkg/controller/cluster/cluster_reconcile_test.go
+++ b/pkg/controller/cluster/cluster_reconcile_test.go
@@ -75,6 +75,15 @@ func TestReconcileCluster_Reconcile(t *testing.T) {
 			objs := []runtime.Object{
 				tenant,
 				&synv1alpha1.GitRepo{},
+				&synv1alpha1.Tenant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.fields.tenantName,
+						Namespace: tt.fields.objNamespace,
+					},
+					Spec: synv1alpha1.TenantSpec{
+						GitRepoTemplate: &synv1alpha1.GitRepoTemplate{},
+					},
+				},
 			}
 
 			cl, s := testSetupClient(objs)
@@ -128,6 +137,12 @@ func TestReconcileCluster_Reconcile(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, roleBinding.RoleRef.Name, role.Name)
 			assert.Equal(t, roleBinding.Subjects[0].Name, sa.Name)
+
+			testTenant := &synv1alpha1.Tenant{}
+			assert.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: tt.fields.tenantName}, testTenant))
+			_, found := testTenant.Spec.GitRepoTemplate.TemplateFiles[tt.fields.objName+".yml"]
+			assert.True(t, found)
+
 		})
 	}
 }

--- a/pkg/controller/gitrepo/gitrepo_reconcile.go
+++ b/pkg/controller/gitrepo/gitrepo_reconcile.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -31,112 +32,115 @@ func (r *ReconcileGitRepo) Reconcile(request reconcile.Request) (reconcile.Resul
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling GitRepo")
 
-	// Fetch the GitRepo instance
-	instance := &synv1alpha1.GitRepo{}
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Fetch the GitRepo instance
+		instance := &synv1alpha1.GitRepo{}
 
-	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return reconcile.Result{}, nil
-		}
-		return reconcile.Result{}, err
-	}
-	helpers.AddTenantLabel(&instance.ObjectMeta, instance.Spec.TenantRef.Name)
-	if instance.Spec.RepoType == synv1alpha1.DefaultRepoType {
-		instance.Spec.RepoType = synv1alpha1.AutoRepoType
-	}
-	secret := &corev1.Secret{}
-	namespacedName := types.NamespacedName{
-		Name:      instance.Spec.APISecretRef.Name,
-		Namespace: instance.Namespace,
-	}
-
-	if len(instance.Spec.APISecretRef.Namespace) > 0 {
-		namespacedName.Namespace = instance.Spec.APISecretRef.Namespace
-	}
-
-	err = r.client.Get(context.TODO(), namespacedName, secret)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("error getting git secret: %v", err)
-	}
-
-	if hostKeys, ok := secret.Data[SecretHostKeysName]; ok {
-		instance.Status.HostKeys = string(hostKeys)
-	}
-
-	if _, ok := secret.Data[SecretEndpointName]; !ok {
-		return reconcile.Result{}, fmt.Errorf("secret %s does not contain endpoint data", secret.GetName())
-	}
-
-	if _, ok := secret.Data[SecretTokenName]; !ok {
-		return reconcile.Result{}, fmt.Errorf("secret %s does not contain token", secret.GetName())
-	}
-
-	repoURL, err := url.Parse(string(secret.Data[SecretEndpointName]) + "/" + instance.Spec.Path + "/" + instance.Spec.RepoName)
-
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	repoOptions := manager.RepoOptions{
-		Credentials: manager.Credentials{
-			Token: string(secret.Data[SecretTokenName]),
-		},
-		DeployKeys:    instance.Spec.DeployKeys,
-		Logger:        reqLogger,
-		Path:          instance.Spec.Path,
-		RepoName:      instance.Spec.RepoName,
-		URL:           repoURL,
-		TemplateFiles: instance.Spec.TemplateFiles,
-	}
-
-	repo, err := manager.NewRepo(repoOptions)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	err = repo.Connect()
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if !r.repoExists(repo) {
-		reqLogger.Info("creating git repo", SecretEndpointName, repoOptions.URL)
-		err = repo.Create()
+		err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 		if err != nil {
-			return r.handleRepoError(err, instance, repo)
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		helpers.AddTenantLabel(&instance.ObjectMeta, instance.Spec.TenantRef.Name)
+		if instance.Spec.RepoType == synv1alpha1.DefaultRepoType {
+			instance.Spec.RepoType = synv1alpha1.AutoRepoType
+		}
+		secret := &corev1.Secret{}
+		namespacedName := types.NamespacedName{
+			Name:      instance.Spec.APISecretRef.Name,
+			Namespace: instance.Namespace,
+		}
+
+		if len(instance.Spec.APISecretRef.Namespace) > 0 {
+			namespacedName.Namespace = instance.Spec.APISecretRef.Namespace
+		}
+
+		err = r.client.Get(context.TODO(), namespacedName, secret)
+		if err != nil {
+			return fmt.Errorf("error getting git secret: %v", err)
+		}
+
+		if hostKeys, ok := secret.Data[SecretHostKeysName]; ok {
+			instance.Status.HostKeys = string(hostKeys)
+		}
+
+		if _, ok := secret.Data[SecretEndpointName]; !ok {
+			return fmt.Errorf("secret %s does not contain endpoint data", secret.GetName())
+		}
+
+		if _, ok := secret.Data[SecretTokenName]; !ok {
+			return fmt.Errorf("secret %s does not contain token", secret.GetName())
+		}
+
+		repoURL, err := url.Parse(string(secret.Data[SecretEndpointName]) + "/" + instance.Spec.Path + "/" + instance.Spec.RepoName)
+
+		if err != nil {
+			return err
+		}
+
+		repoOptions := manager.RepoOptions{
+			Credentials: manager.Credentials{
+				Token: string(secret.Data[SecretTokenName]),
+			},
+			DeployKeys:    instance.Spec.DeployKeys,
+			Logger:        reqLogger,
+			Path:          instance.Spec.Path,
+			RepoName:      instance.Spec.RepoName,
+			URL:           repoURL,
+			TemplateFiles: instance.Spec.TemplateFiles,
+		}
+
+		repo, err := manager.NewRepo(repoOptions)
+		if err != nil {
+			return err
+		}
+
+		err = repo.Connect()
+		if err != nil {
+			return err
+		}
+
+		if !r.repoExists(repo) {
+			reqLogger.Info("creating git repo", SecretEndpointName, repoOptions.URL)
+			err = repo.Create()
+			if err != nil {
+				return r.handleRepoError(err, instance, repo)
+			}
+
+			err = repo.CommitTemplateFiles()
+			if err != nil {
+				return r.handleRepoError(err, instance, repo)
+
+			}
+
+			reqLogger.Info("successfully created the repository")
+			phase := synv1alpha1.Created
+			instance.Status.Phase = &phase
+			instance.Status.URL = repo.FullURL().String()
+			return r.client.Status().Update(context.TODO(), instance)
 		}
 
 		err = repo.CommitTemplateFiles()
 		if err != nil {
 			return r.handleRepoError(err, instance, repo)
-
 		}
 
-		reqLogger.Info("successfully created the repository")
-		phase := synv1alpha1.Created
-		instance.Status.Phase = &phase
-		instance.Status.URL = repo.FullURL().String()
-		return reconcile.Result{}, r.client.Status().Update(context.TODO(), instance)
-	}
+		changed, err := repo.Update()
+		if err != nil {
+			return err
+		}
 
-	err = repo.CommitTemplateFiles()
-	if err != nil {
-		return r.handleRepoError(err, instance, repo)
-	}
+		if changed {
+			reqLogger.Info("keys differed from CRD, keys re-applied to repository")
+		}
 
-	changed, err := repo.Update()
-	if err != nil {
-		return reconcile.Result{}, err
-	}
+		helpers.AddTenantLabel(&instance.ObjectMeta, instance.Spec.TenantRef.Name)
+		return r.client.Status().Update(context.TODO(), instance)
+	})
 
-	if changed {
-		reqLogger.Info("keys differed from CRD, keys re-applied to repository")
-	}
-
-	helpers.AddTenantLabel(&instance.ObjectMeta, instance.Spec.TenantRef.Name)
-
-	return reconcile.Result{}, r.client.Status().Update(context.TODO(), instance)
+	return reconcile.Result{}, err
 }
 
 func (r *ReconcileGitRepo) repoExists(repo manager.Repo) bool {
@@ -147,12 +151,12 @@ func (r *ReconcileGitRepo) repoExists(repo manager.Repo) bool {
 	return false
 }
 
-func (r *ReconcileGitRepo) handleRepoError(err error, instance *synv1alpha1.GitRepo, repo manager.Repo) (reconcile.Result, error) {
+func (r *ReconcileGitRepo) handleRepoError(err error, instance *synv1alpha1.GitRepo, repo manager.Repo) error {
 	phase := synv1alpha1.Failed
 	instance.Status.Phase = &phase
 	instance.Status.URL = repo.FullURL().String()
 	if updateErr := r.client.Status().Update(context.TODO(), instance); updateErr != nil {
-		return reconcile.Result{}, fmt.Errorf("could not set status while handling error: %s: %s", updateErr, err)
+		return fmt.Errorf("could not set status while handling error: %s: %s", updateErr, err)
 	}
-	return reconcile.Result{}, err
+	return err
 }

--- a/pkg/controller/gitrepo/gitrepo_reconcile_test.go
+++ b/pkg/controller/gitrepo/gitrepo_reconcile_test.go
@@ -171,3 +171,7 @@ func (t testRepoImplementation) Delete() error {
 func (t testRepoImplementation) Connect() error {
 	return nil
 }
+
+func (t testRepoImplementation) CommitTemplateFiles() error {
+	return nil
+}

--- a/pkg/git/manager/manager.go
+++ b/pkg/git/manager/manager.go
@@ -42,12 +42,13 @@ func NewRepo(opts RepoOptions) (Repo, error) {
 // RepoOptions hold the options for creating a repository. The credentials are required to work. The deploykeys are
 // optional but desired.
 type RepoOptions struct {
-	Credentials Credentials
-	DeployKeys  map[string]synv1alpha1.DeployKey
-	Logger      logr.Logger
-	URL         *url.URL
-	Path        string
-	RepoName    string
+	Credentials   Credentials
+	DeployKeys    map[string]synv1alpha1.DeployKey
+	Logger        logr.Logger
+	URL           *url.URL
+	Path          string
+	RepoName      string
+	TemplateFiles map[string]string
 }
 
 // Credentials holds the authentication information for the API. Most of the times this
@@ -71,6 +72,8 @@ type Repo interface {
 	Read() error
 	Delete() error
 	Connect() error
+	// CommitTemplateFiles uploads given files to the repository
+	CommitTemplateFiles() error
 }
 
 // Implementation is a set of functions needed to get the right git implementation


### PR DESCRIPTION
 
With this commit the GitRepo CRD was extended so it can hold a map of
file and content. Currently it's only tested to create files in the
root of a repository and not deeper in the file tree.
    
Also each cluster will now create an empty template file in its tenant
repository.
    
Relates to: #36