### PR TITLE
Add git repository description

### DIFF
--- a/deploy/crds/syn.tools_clusters_crd.yaml
+++ b/deploy/crds/syn.tools_clusters_crd.yaml
@@ -87,6 +87,9 @@ spec:
                   description: DeployKeys optional list of SSH deploy keys. If not
                     set, not deploy keys will be configured
                   type: object
+                displayName:
+                  description: DisplayName of Git repository
+                  type: string
                 path:
                   description: Path to Git repository
                   type: string

--- a/deploy/crds/syn.tools_gitrepos_crd.yaml
+++ b/deploy/crds/syn.tools_gitrepos_crd.yaml
@@ -72,6 +72,9 @@ spec:
               description: DeployKeys optional list of SSH deploy keys. If not set,
                 not deploy keys will be configured
               type: object
+            displayName:
+              description: DisplayName of Git repository
+              type: string
             path:
               description: Path to Git repository
               type: string

--- a/deploy/crds/syn.tools_tenants_crd.yaml
+++ b/deploy/crds/syn.tools_tenants_crd.yaml
@@ -76,6 +76,9 @@ spec:
                   description: DeployKeys optional list of SSH deploy keys. If not
                     set, not deploy keys will be configured
                   type: object
+                displayName:
+                  description: DisplayName of Git repository
+                  type: string
                 path:
                   description: Path to Git repository
                   type: string

--- a/docs/modules/ROOT/partials/crds.html
+++ b/docs/modules/ROOT/partials/crds.html
@@ -854,6 +854,21 @@ RepoType
 <tr>
 <td class="tableblock halign-left valign-top">
 <p class="tableblock">
+<code>displayName</code></br>
+<em>
+string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>DisplayName of Git repository</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
 <code>templateFiles</code></br>
 <em>
 map[string]string

--- a/pkg/apis/syn/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/syn/v1alpha1/gitrepo_types.go
@@ -59,6 +59,8 @@ type GitRepoTemplate struct {
 	// RepoType specifies if a repo should be managed by the git controller. A value of 'unmanaged' means it's not manged by the controller
 	// +kubebuilder:validation:Enum=auto;unmanaged
 	RepoType RepoType `json:"repoType,omitempty"`
+	// DisplayName of Git repository
+	DisplayName string `json:"displayName,omitempty"`
 	// TemplateFiles is a list of files that should be pushed to the repository
 	// after its creation.
 	TemplateFiles map[string]string `json:"templateFiles,omitempty"`

--- a/pkg/controller/cluster/cluster_reconcile.go
+++ b/pkg/controller/cluster/cluster_reconcile.go
@@ -54,6 +54,10 @@ func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Resul
 		Kind:    instance.Kind,
 	}
 
+	if len(instance.Spec.GitRepoTemplate.DisplayName) == 0 {
+		instance.Spec.GitRepoTemplate.DisplayName = instance.Spec.DisplayName
+	}
+
 	err = helpers.CreateOrUpdateGitRepo(instance, gvk, instance.Spec.GitRepoTemplate, r.client, instance.Spec.TenantRef)
 	if err != nil {
 		reqLogger.Error(err, "Cannot create or update git repo object")

--- a/pkg/controller/cluster/cluster_reconcile_test.go
+++ b/pkg/controller/cluster/cluster_reconcile_test.go
@@ -61,7 +61,7 @@ func TestReconcileCluster_Reconcile(t *testing.T) {
 					Namespace: tt.fields.objNamespace,
 				},
 				Spec: synv1alpha1.ClusterSpec{
-					DisplayName: "test",
+					DisplayName: "desc",
 					GitRepoTemplate: &synv1alpha1.GitRepoTemplate{
 						RepoName: "test",
 						Path:     "test",
@@ -115,6 +115,7 @@ func TestReconcileCluster_Reconcile(t *testing.T) {
 			gitRepo := &synv1alpha1.GitRepo{}
 			err = cl.Get(context.TODO(), gitRepoNamespacedName, gitRepo)
 			assert.NoError(t, err)
+			assert.Equal(t, cluster.Spec.DisplayName, gitRepo.Spec.GitRepoTemplate.DisplayName)
 
 			newCluster := &synv1alpha1.Cluster{}
 			err = cl.Get(context.TODO(), req.NamespacedName, newCluster)

--- a/pkg/controller/gitrepo/gitrepo_reconcile.go
+++ b/pkg/controller/gitrepo/gitrepo_reconcile.go
@@ -88,6 +88,7 @@ func (r *ReconcileGitRepo) Reconcile(request reconcile.Request) (reconcile.Resul
 			Logger:        reqLogger,
 			Path:          instance.Spec.Path,
 			RepoName:      instance.Spec.RepoName,
+			DisplayName:   instance.Spec.DisplayName,
 			URL:           repoURL,
 			TemplateFiles: instance.Spec.TemplateFiles,
 		}

--- a/pkg/controller/tenant/tenant_reconcile.go
+++ b/pkg/controller/tenant/tenant_reconcile.go
@@ -38,6 +38,10 @@ func (r *ReconcileTenant) Reconcile(request reconcile.Request) (reconcile.Result
 		Kind:    instance.Kind,
 	}
 
+	if len(instance.Spec.GitRepoTemplate.DisplayName) == 0 {
+		instance.Spec.GitRepoTemplate.DisplayName = instance.Spec.DisplayName
+	}
+
 	err = helpers.CreateOrUpdateGitRepo(instance, gvk, instance.Spec.GitRepoTemplate, r.client, corev1.LocalObjectReference{Name: instance.GetName()})
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/tenant/tenant_reconcile_test.go
+++ b/pkg/controller/tenant/tenant_reconcile_test.go
@@ -88,7 +88,7 @@ func TestCreateGitRepo(t *testing.T) {
 			gitRepo := &synv1alpha1.GitRepo{}
 			err = cl.Get(context.TODO(), gitRepoNamespacedName, gitRepo)
 			assert.NoError(t, err)
-
+			assert.Equal(t, tenant.Spec.DisplayName, gitRepo.Spec.GitRepoTemplate.DisplayName)
 		})
 	}
 }

--- a/pkg/git/gitlab/gitlab_test.go
+++ b/pkg/git/gitlab/gitlab_test.go
@@ -1,6 +1,8 @@
 package gitlab
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/projectsyn/lieutenant-operator/pkg/git/manager"
+	"github.com/stretchr/testify/assert"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -109,8 +112,16 @@ func testGetCreateServer() *httptest.Server {
 	})
 
 	mux.HandleFunc("/api/v4/projects", func(res http.ResponseWriter, req *http.Request) {
-		res.WriteHeader(http.StatusOK)
-		_, _ = res.Write([]byte(`{"id":3,"description":null,"default_branch":"master","visibility":"private","ssh_url_to_repo":"git@example.com:diaspora/diaspora-project-site.git","http_url_to_repo":"http://example.com/diaspora/diaspora-project-site.git","web_url":"http://example.com/diaspora/diaspora-project-site","readme_url":"http://example.com/diaspora/diaspora-project-site/blob/master/README.md","tag_list":["example","disapora project"],"owner":{"id":3,"name":"Diaspora","created_at":"2013-09-30T13:46:02Z"},"name":"Diaspora Project Site","name_with_namespace":"group1 / Diaspora Project Site","path":"diaspora-project-site","path_with_namespace":"group1/diaspora-project-site","issues_enabled":true,"open_issues_count":1,"merge_requests_enabled":true,"jobs_enabled":true,"wiki_enabled":true,"snippets_enabled":false,"resolve_outdated_diff_discussions":false,"container_registry_enabled":false,"container_expiration_policy":{"cadence":"7d","enabled":false,"keep_n":null,"older_than":null,"name_regex":null,"next_run_at":"2020-01-07T21:42:58.658Z"},"created_at":"2013-09-30T13:46:02Z","last_activity_at":"2013-09-30T13:46:02Z","creator_id":2,"namespace":{"id":2,"name":"group1","path":"group1","kind":"group","full_path":"group1","parent_id":null,"members_count_with_descendants":2},"import_status":"none","import_error":null,"permissions":{"project_access":{"access_level":10,"notification_level":3},"group_access":{"access_level":50,"notification_level":3}},"archived":false,"avatar_url":"http://example.com/uploads/project/avatar/3/uploads/avatar.png","license_url":"http://example.com/diaspora/diaspora-client/blob/master/LICENSE","license":{"key":"lgpl-3.0","name":"GNU Lesser General Public License v3.0","nickname":"GNU LGPLv3","html_url":"http://choosealicense.com/licenses/lgpl-3.0/","source_url":"http://www.gnu.org/licenses/lgpl-3.0.txt"},"shared_runners_enabled":true,"forks_count":0,"star_count":0,"runners_token":"b8bc4a7a29eb76ea83cf79e4908c2b","ci_default_git_depth":50,"public_jobs":true,"shared_with_groups":[{"group_id":4,"group_name":"Twitter","group_full_path":"twitter","group_access_level":30},{"group_id":3,"group_name":"Gitlab Org","group_full_path":"gitlab-org","group_access_level":10}],"repository_storage":"default","only_allow_merge_if_pipeline_succeeds":false,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":false,"printing_merge_requests_link_enabled":true,"request_access_enabled":false,"merge_method":"merge","auto_devops_enabled":true,"auto_devops_deploy_strategy":"continuous","approvals_before_merge":0,"mirror":false,"mirror_user_id":45,"mirror_trigger_builds":false,"only_mirror_protected_branches":false,"mirror_overwrites_diverged_branches":false,"external_authorization_classification_label":null,"packages_enabled":true,"service_desk_enabled":false,"service_desk_address":null,"autoclose_referenced_issues":true,"suggestion_commit_message":null,"statistics":{"commit_count":37,"storage_size":1038090,"repository_size":1038090,"wiki_size":0,"lfs_objects_size":0,"job_artifacts_size":0,"packages_size":0},"_links":{"self":"http://example.com/api/v4/projects","issues":"http://example.com/api/v4/projects/1/issues","merge_requests":"http://example.com/api/v4/projects/1/merge_requests","repo_branches":"http://example.com/api/v4/projects/1/repository_branches","labels":"http://example.com/api/v4/projects/1/labels","events":"http://example.com/api/v4/projects/1/events","members":"http://example.com/api/v4/projects/1/members"}}`))
+		createProjectOptions := gitlab.CreateProjectOptions{}
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(req.Body)
+		err := json.Unmarshal(buf.Bytes(), &createProjectOptions)
+		response := http.StatusOK
+		if err != nil {
+			response = http.StatusInternalServerError
+		}
+		res.WriteHeader(response)
+		_, _ = res.Write([]byte(`{"id":3,"description":"` + *createProjectOptions.Description + `","default_branch":"master","visibility":"private","ssh_url_to_repo":"git@example.com:diaspora/diaspora-project-site.git","http_url_to_repo":"http://example.com/diaspora/diaspora-project-site.git","web_url":"http://example.com/diaspora/diaspora-project-site","readme_url":"http://example.com/diaspora/diaspora-project-site/blob/master/README.md","tag_list":["example","disapora project"],"owner":{"id":3,"name":"Diaspora","created_at":"2013-09-30T13:46:02Z"},"name":"`+ *createProjectOptions.Name +`","name_with_namespace":"group1 / Diaspora Project Site","path":"diaspora-project-site","path_with_namespace":"group1/diaspora-project-site","issues_enabled":true,"open_issues_count":1,"merge_requests_enabled":true,"jobs_enabled":true,"wiki_enabled":true,"snippets_enabled":false,"resolve_outdated_diff_discussions":false,"container_registry_enabled":false,"container_expiration_policy":{"cadence":"7d","enabled":false,"keep_n":null,"older_than":null,"name_regex":null,"next_run_at":"2020-01-07T21:42:58.658Z"},"created_at":"2013-09-30T13:46:02Z","last_activity_at":"2013-09-30T13:46:02Z","creator_id":2,"namespace":{"id":2,"name":"group1","path":"group1","kind":"group","full_path":"group1","parent_id":null,"members_count_with_descendants":2},"import_status":"none","import_error":null,"permissions":{"project_access":{"access_level":10,"notification_level":3},"group_access":{"access_level":50,"notification_level":3}},"archived":false,"avatar_url":"http://example.com/uploads/project/avatar/3/uploads/avatar.png","license_url":"http://example.com/diaspora/diaspora-client/blob/master/LICENSE","license":{"key":"lgpl-3.0","name":"GNU Lesser General Public License v3.0","nickname":"GNU LGPLv3","html_url":"http://choosealicense.com/licenses/lgpl-3.0/","source_url":"http://www.gnu.org/licenses/lgpl-3.0.txt"},"shared_runners_enabled":true,"forks_count":0,"star_count":0,"runners_token":"b8bc4a7a29eb76ea83cf79e4908c2b","ci_default_git_depth":50,"public_jobs":true,"shared_with_groups":[{"group_id":4,"group_name":"Twitter","group_full_path":"twitter","group_access_level":30},{"group_id":3,"group_name":"Gitlab Org","group_full_path":"gitlab-org","group_access_level":10}],"repository_storage":"default","only_allow_merge_if_pipeline_succeeds":false,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":false,"printing_merge_requests_link_enabled":true,"request_access_enabled":false,"merge_method":"merge","auto_devops_enabled":true,"auto_devops_deploy_strategy":"continuous","approvals_before_merge":0,"mirror":false,"mirror_user_id":45,"mirror_trigger_builds":false,"only_mirror_protected_branches":false,"mirror_overwrites_diverged_branches":false,"external_authorization_classification_label":null,"packages_enabled":true,"service_desk_enabled":false,"service_desk_address":null,"autoclose_referenced_issues":true,"suggestion_commit_message":null,"statistics":{"commit_count":37,"storage_size":1038090,"repository_size":1038090,"wiki_size":0,"lfs_objects_size":0,"job_artifacts_size":0,"packages_size":0},"_links":{"self":"http://example.com/api/v4/projects","issues":"http://example.com/api/v4/projects/1/issues","merge_requests":"http://example.com/api/v4/projects/1/merge_requests","repo_branches":"http://example.com/api/v4/projects/1/repository_branches","labels":"http://example.com/api/v4/projects/1/labels","events":"http://example.com/api/v4/projects/1/events","members":"http://example.com/api/v4/projects/1/members"}}`))
 	})
 
 	mux.HandleFunc("/api/v4/namespaces/group1", func(res http.ResponseWriter, req *http.Request) {
@@ -129,7 +140,6 @@ func testGetCreateServer() *httptest.Server {
 	})
 
 	return httptest.NewServer(mux)
-
 }
 
 func TestGitlab_Create(t *testing.T) {
@@ -137,6 +147,7 @@ func TestGitlab_Create(t *testing.T) {
 		credentials manager.Credentials
 		namespace   string
 		projectname string
+		description string
 	}
 	tests := []struct {
 		name       string
@@ -150,6 +161,7 @@ func TestGitlab_Create(t *testing.T) {
 				credentials: manager.Credentials{},
 				namespace:   "group1",
 				projectname: "test",
+				description: "desc",
 			},
 			httpServer: testGetCreateServer(),
 			wantErr:    false,
@@ -173,9 +185,10 @@ func TestGitlab_Create(t *testing.T) {
 			g := &Gitlab{
 				credentials: tt.fields.credentials,
 				ops: manager.RepoOptions{
-					URL:      serverURL,
-					Path:     tt.fields.namespace,
-					RepoName: tt.fields.projectname,
+					URL:         serverURL,
+					Path:        tt.fields.namespace,
+					RepoName:    tt.fields.projectname,
+					DisplayName: tt.fields.description,
 				},
 			}
 
@@ -183,6 +196,10 @@ func TestGitlab_Create(t *testing.T) {
 
 			if err := g.Create(); (err != nil) != tt.wantErr {
 				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				assert.Equal(t, tt.fields.description, g.project.Description, "Description should have been populated")
+				assert.Equal(t, tt.fields.projectname, g.project.Name, "Name should have been populated")
 			}
 		})
 	}
@@ -247,6 +264,26 @@ func testGetUpdateServer(fail bool) *httptest.Server {
 		_, _ = res.Write([]byte(`[{"id":1,"title":"Public key","key":"ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0=","created_at":"2013-10-02T10:12:29Z","can_push":false},{"id":3,"title":"Another Public key","key":"ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAIEAiPWx6WM4lhHNedGfBpPJNPpZ7yKu+dnn1SJejgt4596k6YjzGGphH2TUxwKzxcKDKKezwkpfnxPkSMkuEspGRt/aZZ9wa++Oi7Qkr8prgHc4soW6NUlfDzpvZK2H5E7eQaSeP3SAwGmQKUFHCddNaP0L+hM7zhFNzjFvpaMgJw0=","created_at":"2013-10-02T11:12:29Z","can_push":false}]`))
 	})
 
+	mux.HandleFunc("/api/v4/projects/updated/repo", func(res http.ResponseWriter, req *http.Request) {
+
+		respH := http.StatusOK
+		res.WriteHeader(respH)
+		_, _ = res.Write([]byte(`{"id":3,"description":"oldDesc","default_branch":"master","visibility":"private","ssh_url_to_repo":"git@example.com:luzifern/luzifern-project-site.git","http_url_to_repo":"http://example.com/diaspora/diaspora-project-site.git","web_url":"http://example.com/diaspora/diaspora-project-site","readme_url":"http://example.com/diaspora/diaspora-project-site/blob/master/README.md","tag_list":["example","disapora project"],"owner":{"id":3,"name":"Diaspora","created_at":"2013-09-30T13:46:02Z"},"name":"repo","name_with_namespace":"group1 / Diaspora Project Site","path":"diaspora-project-site","path_with_namespace":"group1/diaspora-project-site","issues_enabled":true,"open_issues_count":1,"merge_requests_enabled":true,"jobs_enabled":true,"wiki_enabled":true,"snippets_enabled":false,"resolve_outdated_diff_discussions":false,"container_registry_enabled":false,"container_expiration_policy":{"cadence":"7d","enabled":false,"keep_n":null,"older_than":null,"name_regex":null,"next_run_at":"2020-01-07T21:42:58.658Z"},"created_at":"2013-09-30T13:46:02Z","last_activity_at":"2013-09-30T13:46:02Z","creator_id":2,"namespace":{"id":2,"name":"group1","path":"group1","kind":"group","full_path":"group1","parent_id":null,"members_count_with_descendants":2},"import_status":"none","import_error":null,"permissions":{"project_access":{"access_level":10,"notification_level":3},"group_access":{"access_level":50,"notification_level":3}},"archived":false,"avatar_url":"http://example.com/uploads/project/avatar/3/uploads/avatar.png","license_url":"http://example.com/diaspora/diaspora-client/blob/master/LICENSE","license":{"key":"lgpl-3.0","name":"GNU Lesser General Public License v3.0","nickname":"GNU LGPLv3","html_url":"http://choosealicense.com/licenses/lgpl-3.0/","source_url":"http://www.gnu.org/licenses/lgpl-3.0.txt"},"shared_runners_enabled":true,"forks_count":0,"star_count":0,"runners_token":"b8bc4a7a29eb76ea83cf79e4908c2b","ci_default_git_depth":50,"public_jobs":true,"shared_with_groups":[{"group_id":4,"group_name":"Twitter","group_full_path":"twitter","group_access_level":30},{"group_id":3,"group_name":"Gitlab Org","group_full_path":"gitlab-org","group_access_level":10}],"repository_storage":"default","only_allow_merge_if_pipeline_succeeds":false,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":false,"printing_merge_requests_link_enabled":true,"request_access_enabled":false,"merge_method":"merge","auto_devops_enabled":true,"auto_devops_deploy_strategy":"continuous","approvals_before_merge":0,"mirror":false,"mirror_user_id":45,"mirror_trigger_builds":false,"only_mirror_protected_branches":false,"mirror_overwrites_diverged_branches":false,"external_authorization_classification_label":null,"packages_enabled":true,"service_desk_enabled":false,"service_desk_address":null,"autoclose_referenced_issues":true,"suggestion_commit_message":null,"statistics":{"commit_count":37,"storage_size":1038090,"repository_size":1038090,"wiki_size":0,"lfs_objects_size":0,"job_artifacts_size":0,"packages_size":0},"_links":{"self":"http://example.com/api/v4/projects","issues":"http://example.com/api/v4/projects/1/issues","merge_requests":"http://example.com/api/v4/projects/1/merge_requests","repo_branches":"http://example.com/api/v4/projects/1/repository_branches","labels":"http://example.com/api/v4/projects/1/labels","events":"http://example.com/api/v4/projects/1/events","members":"http://example.com/api/v4/projects/1/members"}}`))
+	})
+
+	mux.HandleFunc("/api/v4/projects/3", func(res http.ResponseWriter, req *http.Request) {
+		editProjectOptions := gitlab.EditProjectOptions{}
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(req.Body)
+		err := json.Unmarshal(buf.Bytes(), &editProjectOptions)
+		response := http.StatusOK
+		if err != nil {
+			response = http.StatusInternalServerError
+		}
+		res.WriteHeader(response)
+		_, _ = res.Write([]byte(`{"id":3,"description":"`+*editProjectOptions.Description+`","default_branch":"master","visibility":"private","ssh_url_to_repo":"git@example.com:luzifern/luzifern-project-site.git","http_url_to_repo":"http://example.com/diaspora/diaspora-project-site.git","web_url":"http://example.com/diaspora/diaspora-project-site","readme_url":"http://example.com/diaspora/diaspora-project-site/blob/master/README.md","tag_list":["example","disapora project"],"owner":{"id":3,"name":"Diaspora","created_at":"2013-09-30T13:46:02Z"},"name":"repo","name_with_namespace":"group1 / Diaspora Project Site","path":"diaspora-project-site","path_with_namespace":"group1/diaspora-project-site","issues_enabled":true,"open_issues_count":1,"merge_requests_enabled":true,"jobs_enabled":true,"wiki_enabled":true,"snippets_enabled":false,"resolve_outdated_diff_discussions":false,"container_registry_enabled":false,"container_expiration_policy":{"cadence":"7d","enabled":false,"keep_n":null,"older_than":null,"name_regex":null,"next_run_at":"2020-01-07T21:42:58.658Z"},"created_at":"2013-09-30T13:46:02Z","last_activity_at":"2013-09-30T13:46:02Z","creator_id":2,"namespace":{"id":2,"name":"group1","path":"group1","kind":"group","full_path":"group1","parent_id":null,"members_count_with_descendants":2},"import_status":"none","import_error":null,"permissions":{"project_access":{"access_level":10,"notification_level":3},"group_access":{"access_level":50,"notification_level":3}},"archived":false,"avatar_url":"http://example.com/uploads/project/avatar/3/uploads/avatar.png","license_url":"http://example.com/diaspora/diaspora-client/blob/master/LICENSE","license":{"key":"lgpl-3.0","name":"GNU Lesser General Public License v3.0","nickname":"GNU LGPLv3","html_url":"http://choosealicense.com/licenses/lgpl-3.0/","source_url":"http://www.gnu.org/licenses/lgpl-3.0.txt"},"shared_runners_enabled":true,"forks_count":0,"star_count":0,"runners_token":"b8bc4a7a29eb76ea83cf79e4908c2b","ci_default_git_depth":50,"public_jobs":true,"shared_with_groups":[{"group_id":4,"group_name":"Twitter","group_full_path":"twitter","group_access_level":30},{"group_id":3,"group_name":"Gitlab Org","group_full_path":"gitlab-org","group_access_level":10}],"repository_storage":"default","only_allow_merge_if_pipeline_succeeds":false,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":false,"printing_merge_requests_link_enabled":true,"request_access_enabled":false,"merge_method":"merge","auto_devops_enabled":true,"auto_devops_deploy_strategy":"continuous","approvals_before_merge":0,"mirror":false,"mirror_user_id":45,"mirror_trigger_builds":false,"only_mirror_protected_branches":false,"mirror_overwrites_diverged_branches":false,"external_authorization_classification_label":null,"packages_enabled":true,"service_desk_enabled":false,"service_desk_address":null,"autoclose_referenced_issues":true,"suggestion_commit_message":null,"statistics":{"commit_count":37,"storage_size":1038090,"repository_size":1038090,"wiki_size":0,"lfs_objects_size":0,"job_artifacts_size":0,"packages_size":0},"_links":{"self":"http://example.com/api/v4/projects","issues":"http://example.com/api/v4/projects/1/issues","merge_requests":"http://example.com/api/v4/projects/1/merge_requests","repo_branches":"http://example.com/api/v4/projects/1/repository_branches","labels":"http://example.com/api/v4/projects/1/labels","events":"http://example.com/api/v4/projects/1/events","members":"http://example.com/api/v4/projects/1/members"}}`))
+	})
+
 	deleteOk := func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusOK)
 		_, _ = res.Write([]byte(`{"message":"202 Accepted"}`))
@@ -275,6 +312,9 @@ func TestGitlab_Update(t *testing.T) {
 			fields: fields{
 				project: &gitlab.Project{
 					ID: 3,
+					Path: "updated",
+					Name: "repo",
+					Description: "newDesc",
 				},
 			},
 			wantErr:    false,
@@ -285,6 +325,9 @@ func TestGitlab_Update(t *testing.T) {
 			fields: fields{
 				project: &gitlab.Project{
 					ID: 1,
+					Path: "updated",
+					Name: "repo",
+					Description: "newDesc",
 				},
 			},
 			wantErr:    true,
@@ -301,6 +344,9 @@ func TestGitlab_Update(t *testing.T) {
 			g := &Gitlab{
 				ops: manager.RepoOptions{
 					URL: serverURL,
+					Path: tt.fields.project.Path,
+					RepoName: tt.fields.project.Name,
+					DisplayName: tt.fields.project.Description,
 				},
 				project: tt.fields.project,
 				log:     zap.Logger(),
@@ -310,6 +356,10 @@ func TestGitlab_Update(t *testing.T) {
 
 			if _, err := g.Update(); (err != nil) != tt.wantErr {
 				t.Errorf("Update() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr {
+				assert.Equal(t, tt.fields.project.Description, g.project.Description, "Description should have been updated")
 			}
 		})
 	}

--- a/pkg/git/manager/manager.go
+++ b/pkg/git/manager/manager.go
@@ -42,13 +42,14 @@ func NewRepo(opts RepoOptions) (Repo, error) {
 // RepoOptions hold the options for creating a repository. The credentials are required to work. The deploykeys are
 // optional but desired.
 type RepoOptions struct {
-	Credentials   Credentials
-	DeployKeys    map[string]synv1alpha1.DeployKey
-	Logger        logr.Logger
-	URL           *url.URL
-	Path          string
-	RepoName      string
-	TemplateFiles map[string]string
+	Credentials       Credentials
+	DeployKeys        map[string]synv1alpha1.DeployKey
+	Logger            logr.Logger
+	URL               *url.URL
+	Path              string
+	RepoName          string
+	DisplayName   	  string
+	TemplateFiles     map[string]string
 }
 
 // Credentials holds the authentication information for the API. Most of the times this


### PR DESCRIPTION
This Pull Request populates GitHub Repository `Description` field.

Here what has been changed:
* Whenever a cluster object is created/updated the `DisplayName` field will be passed as `Description` to GitHub Repository
* Whenever a tenant object is created/updated the `DisplayName` field will be passed as `Description` to GitHub Repository
* Whenever a gitrepo object is created/updated the `DisplayName` field will be passed as `Description` to GitHub Repository
* Added `Description` field management to `Create()` and `Update()` functions
* Added test cases for each modifications