### PR TITLE
Fix reconcile loop with GitRepo updates

### DIFF
--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -9,7 +9,7 @@ spec:
     repoName: cluster1
     apiSecretRef:
       name: example-secret
-      namespace: syn-lieutenant
+      # namespace: syn-lieutenant
     deployKeys:
       test:
         type: ssh-ed25519

--- a/examples/tenant.yaml
+++ b/examples/tenant.yaml
@@ -9,7 +9,7 @@ spec:
     repoName: tenant1
     apiSecretRef:
       name: example-secret
-      namespace: syn-lieutenant
+      # namespace: syn-lieutenant
     deployKeys:
       test:
         type: ssh-ed25519

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/banzaicloud/bank-vaults/pkg/sdk v0.3.0
 	github.com/go-logr/logr v0.1.0
+	github.com/go-test/deep v1.0.6
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/icza/gox v0.0.0-20200320174535-a6ff52ab3d90
+	github.com/imdario/mergo v0.3.9
 	github.com/operator-framework/operator-sdk v0.17.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -375,7 +375,10 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31 h1:28FVBuwkwowZMjbA7M0wXsI6t3PYulRTMio3SO+eKCM=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.6 h1:UHSEyLZUwX9Qoi99vVwvewiMC8mM2bf7XEM2nqvzEn8=
+github.com/go-test/deep v1.0.6/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=
 github.com/gobuffalo/envy v1.7.0 h1:GlXgaiBkmrYMHco6t4j7SacKO4XUjvh5pwXh0f4uxXU=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
@@ -563,6 +566,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
+github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=

--- a/pkg/controller/gitrepo/gitrepo_reconcile_test.go
+++ b/pkg/controller/gitrepo/gitrepo_reconcile_test.go
@@ -135,7 +135,7 @@ func TestReconcileGitRepo_Reconcile(t *testing.T) {
 			assert.NoError(t, err)
 			if !tt.wantErr {
 				assert.Equal(t, string(secret.Data[SecretHostKeysName]), gitRepo.Status.HostKeys)
-				assert.Equal(t, synv1alpha1.AutoRepoType, gitRepo.Spec.RepoType)
+				assert.Equal(t, synv1alpha1.DefaultRepoType, gitRepo.Spec.RepoType)
 				assert.Equal(t, tt.fields.displayName, gitRepo.Spec.DisplayName)
 				assert.Equal(t, tt.fields.displayName, savedGitRepoOpt.DisplayName)
 				assert.Equal(t, tt.fields.tenantName, gitRepo.Labels[apis.LabelNameTenant])

--- a/pkg/helpers/crd_test.go
+++ b/pkg/helpers/crd_test.go
@@ -113,6 +113,12 @@ func TestCreateOrUpdateGitRepo(t *testing.T) {
 		assert.NoError(t, cl.Get(context.TODO(), namespacedName, checkRepo))
 		assert.Equal(t, tt.args.template, &checkRepo.Spec.GitRepoTemplate)
 
+		checkRepo.Spec.RepoType = synv1alpha1.AutoRepoType
+		assert.NoError(t, cl.Update(context.TODO(), checkRepo))
+		assert.NoError(t, CreateOrUpdateGitRepo(tt.args.obj, tt.args.gvk, tt.args.template, cl, tt.args.tenantRef))
+		finalRepo := &synv1alpha1.GitRepo{}
+		assert.NoError(t, cl.Get(context.TODO(), namespacedName, finalRepo))
+		assert.Equal(t, checkRepo.Spec.GitRepoTemplate, finalRepo.Spec.GitRepoTemplate)
 	}
 }
 


### PR DESCRIPTION
Updating the git repository every on every reconcile triggers a loop.
Not quite sure why it happens though, the diffs of the GitRepo objects
don't show any differences apart from `generation` and `resourceVersion`.

The operator will permanently reconcile all tenants and clusters as they
have the Gitrepository as their secondary objects. That triggers and
endless loop of reconciles.

Resolves: #54 