### PR TITLE
Tenant Common

### DIFF
--- a/pkg/controller/cluster/cluster_reconcile.go
+++ b/pkg/controller/cluster/cluster_reconcile.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	synv1alpha1 "github.com/projectsyn/lieutenant-operator/pkg/apis/syn/v1alpha1"
+	synTenant "github.com/projectsyn/lieutenant-operator/pkg/controller/tenant"
 	"github.com/projectsyn/lieutenant-operator/pkg/helpers"
 	"github.com/projectsyn/lieutenant-operator/pkg/vault"
 	corev1 "k8s.io/api/core/v1"
@@ -17,7 +18,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	clusterClassContent = `classes:
+- %s.%s
+`
 )
 
 // Reconcile reads that state of the cluster for a Cluster object and makes changes based on the state read
@@ -87,7 +95,7 @@ func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
-	err = r.updateTenantGitRepo(repoName, instance.GetName()+".yml")
+	err = r.updateTenantGitRepo(repoName, instance.GetName())
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -141,29 +149,27 @@ func (r *ReconcileCluster) newStatus(cluster *synv1alpha1.Cluster) error {
 	return nil
 }
 
-func (r *ReconcileCluster) updateTenantGitRepo(tenant types.NamespacedName, filename string) error {
-	tenantCR := &synv1alpha1.Tenant{}
+func (r *ReconcileCluster) updateTenantGitRepo(tenant types.NamespacedName, clusterName string) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		tenantCR := &synv1alpha1.Tenant{}
 
-	err := r.client.Get(context.TODO(), tenant, tenantCR)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
+		err := r.client.Get(context.TODO(), tenant, tenantCR)
+		if err != nil {
+			return err
 		}
-		return err
-	}
 
-	if tenantCR.Spec.GitRepoTemplate.TemplateFiles == nil {
-		tenantCR.Spec.GitRepoTemplate.TemplateFiles = map[string]string{}
-	}
+		if tenantCR.Spec.GitRepoTemplate.TemplateFiles == nil {
+			tenantCR.Spec.GitRepoTemplate.TemplateFiles = map[string]string{}
+		}
 
-	if _, ok := tenantCR.Spec.GitRepoTemplate.TemplateFiles[filename]; !ok {
-
-		tenantCR.Spec.GitRepoTemplate.TemplateFiles[filename] = ""
-
-		return r.client.Update(context.TODO(), tenantCR)
-	}
-
-	return nil
+		clusterClassFile := clusterName + ".yml"
+		if _, ok := tenantCR.Spec.GitRepoTemplate.TemplateFiles[clusterClassFile]; !ok {
+			fileContent := fmt.Sprintf(clusterClassContent, tenant.Name, synTenant.CommonClassName)
+			tenantCR.Spec.GitRepoTemplate.TemplateFiles[clusterClassFile] = fileContent
+			return r.client.Update(context.TODO(), tenantCR)
+		}
+		return nil
+	})
 }
 
 func (r *ReconcileCluster) getServiceAccountToken(instance metav1.Object) (string, error) {

--- a/pkg/controller/cluster/cluster_reconcile_test.go
+++ b/pkg/controller/cluster/cluster_reconcile_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/projectsyn/lieutenant-operator/pkg/apis"
 	synv1alpha1 "github.com/projectsyn/lieutenant-operator/pkg/apis/syn/v1alpha1"
+	"github.com/projectsyn/lieutenant-operator/pkg/controller/tenant"
 	"github.com/projectsyn/lieutenant-operator/pkg/vault"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -171,9 +173,9 @@ func TestReconcileCluster_Reconcile(t *testing.T) {
 			testTenant := &synv1alpha1.Tenant{}
 			err = cl.Get(context.TODO(), types.NamespacedName{Name: tt.fields.tenantName, Namespace: tt.fields.objNamespace}, testTenant)
 			assert.NoError(t, err)
-			_, found := testTenant.Spec.GitRepoTemplate.TemplateFiles[tt.fields.objName+".yml"]
+			fileContent, found := testTenant.Spec.GitRepoTemplate.TemplateFiles[tt.fields.objName+".yml"]
 			assert.True(t, found)
-
+			assert.Equal(t, fileContent, fmt.Sprintf(clusterClassContent, tt.fields.tenantName, tenant.CommonClassName))
 		})
 	}
 }

--- a/pkg/controller/tenant/tenant_reconcile.go
+++ b/pkg/controller/tenant/tenant_reconcile.go
@@ -13,6 +13,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const (
+	// CommonClassName is the name of the tenant's common class
+	CommonClassName = "common"
+)
+
 // Reconcile The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileTenant) Reconcile(request reconcile.Request) (reconcile.Result, error) {
@@ -40,6 +45,14 @@ func (r *ReconcileTenant) Reconcile(request reconcile.Request) (reconcile.Result
 
 	if len(instance.Spec.GitRepoTemplate.DisplayName) == 0 {
 		instance.Spec.GitRepoTemplate.DisplayName = instance.Spec.DisplayName
+	}
+
+	commonClassFile := CommonClassName + ".yml"
+	if instance.Spec.GitRepoTemplate.TemplateFiles == nil {
+		instance.Spec.GitRepoTemplate.TemplateFiles = map[string]string{}
+	}
+	if _, ok := instance.Spec.GitRepoTemplate.TemplateFiles[commonClassFile]; !ok {
+		instance.Spec.GitRepoTemplate.TemplateFiles[commonClassFile] = ""
 	}
 
 	err = helpers.CreateOrUpdateGitRepo(instance, gvk, instance.Spec.GitRepoTemplate, r.client, corev1.LocalObjectReference{Name: instance.GetName()})

--- a/pkg/controller/tenant/tenant_reconcile_test.go
+++ b/pkg/controller/tenant/tenant_reconcile_test.go
@@ -89,6 +89,9 @@ func TestCreateGitRepo(t *testing.T) {
 			err = cl.Get(context.TODO(), gitRepoNamespacedName, gitRepo)
 			assert.NoError(t, err)
 			assert.Equal(t, tenant.Spec.DisplayName, gitRepo.Spec.GitRepoTemplate.DisplayName)
+			fileContent, found := gitRepo.Spec.GitRepoTemplate.TemplateFiles[CommonClassName+".yml"]
+			assert.True(t, found)
+			assert.Equal(t, "", fileContent)
 		})
 	}
 }


### PR DESCRIPTION
Automatically set up a `common.yml` class in each tenant which is included by each cluster of a tenant.

Add option to disable Vault for local development.