### PR TITLE
Make operator sync interval configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+### Added
+- Ability to configure sync interval
+
 ## v0.1.3 - 2020-05-15
 ### Added
 - Create a `common.yml` class for each tenant


### PR DESCRIPTION
This commit makes thes sync interval for the operator configurable. This
should reduce the load on any external components (git, vault, etc.).