### PR TITLE
Fix nilpointer with VAULT client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The operator can now remove external resources: Vault, Git Repository and Files in a repository
 ### Changed
 - Documentation structure
+### Fixed
+- Vault nilpointer if `SKIP_VAULT_SETUP` is set
 
 ## v0.1.5 - 2020-06-12
 ### Added

--- a/pkg/controller/cluster/cluster_reconcile.go
+++ b/pkg/controller/cluster/cluster_reconcile.go
@@ -98,12 +98,12 @@ func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Resul
 			deletionPolicy = helpers.GetDeletionPolicy()
 		}
 
-		vaultClient, err = vault.NewClient(deletionPolicy, reqLogger)
-		if err != nil {
-			return err
-		}
-
 		if strings.ToLower(os.Getenv("SKIP_VAULT_SETUP")) != "true" {
+
+			vaultClient, err = vault.NewClient(deletionPolicy, reqLogger)
+			if err != nil {
+				return err
+			}
 
 			token, err := r.getServiceAccountToken(instance)
 			if err != nil {


### PR DESCRIPTION
If `SKIP_VAULT_SETUP` is set true and a deletion is triggered the Operator run into a nilpointer.

Resolves: #86 