### PR TITLE
Upgraded antora-preview to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ VERSION ?= $(shell git describe --tags --always --dirty --match=v* || (echo "com
 
 IMAGE_NAME ?= docker.io/projectsyn/$(BINARY_NAME):$(VERSION)
 
-ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 2020:2020 --volume "${PWD}":/antora vshn/antora-preview:2.3.3 --style=syn --antora=docs
+ANTORA_PREVIEW_CMD ?= $(DOCKER_CMD) run --rm --publish 35729:35729 --publish 2020:2020 --volume "${PWD}":/preview/antora vshn/antora-preview:2.3.4 --style=syn --antora=docs
 
 VALE_CMD  ?= $(DOCKER_CMD) run $(DOCKER_ARGS) --volume "$${PWD}"/docs/modules:/pages vshn/vale:2.1.1
 VALE_ARGS ?= --minAlertLevel=error --config=/pages/ROOT/pages/.vale.ini /pages


### PR DESCRIPTION
This PR provides upgrades antora-preview to the last version (2.3.4) which includes a new live reloading capability:

1. Run `make docs-serve`.
2. Open http://localhost:2020 on a browser with the [LiveReload plugin](https://github.com/vshn/antora-preview#livereload).
3. Edit your documentation in your preferred editor.
4. Watch your changes appear automatically on the browser.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Update the ./CHANGELOG.md.
- [ ] Link this PR to related issues.
