### PR TITLE
Add configurable revisions for git repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+### Added
+- Configurable revisions for git repositories ([#116])
 
 ## [v0.3.0] - 2020-10-01
 ### Fixed
@@ -108,3 +111,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#103]: https://github.com/projectsyn/lieutenant-operator/pull/103
 [#104]: https://github.com/projectsyn/lieutenant-operator/pull/104
 [#110]: https://github.com/projectsyn/lieutenant-operator/pull/110
+[#116]: https://github.com/projectsyn/lieutenant-operator/pull/116

--- a/deploy/crds/syn.tools_clusters_crd.yaml
+++ b/deploy/crds/syn.tools_clusters_crd.yaml
@@ -115,6 +115,12 @@ spec:
             gitRepoURL:
               description: GitRepoURL git repository storing the cluster configuration catalog. If this is set, no gitRepoTemplate is needed.
               type: string
+            globalGitRepoRevision:
+              description: GlobalGitRepoRevision allows to configure the revision of the global configuration to use. It can be any git tree-ish reference. The revision from the tenant will be inherited if left empty.
+              type: string
+            tenantGitRepoRevision:
+              description: TenantGitRepoRevision allows to configure the revision of the tenant configuration to use. It can be any git tree-ish reference. The revision from the tenant will be inherited if left empty.
+              type: string
             tenantRef:
               description: TenantRef reference to Tenant object the cluster belongs to.
               properties:

--- a/deploy/crds/syn.tools_tenants_crd.yaml
+++ b/deploy/crds/syn.tools_tenants_crd.yaml
@@ -115,6 +115,12 @@ spec:
                 gitRepoURL:
                   description: GitRepoURL git repository storing the cluster configuration catalog. If this is set, no gitRepoTemplate is needed.
                   type: string
+                globalGitRepoRevision:
+                  description: GlobalGitRepoRevision allows to configure the revision of the global configuration to use. It can be any git tree-ish reference. The revision from the tenant will be inherited if left empty.
+                  type: string
+                tenantGitRepoRevision:
+                  description: TenantGitRepoRevision allows to configure the revision of the tenant configuration to use. It can be any git tree-ish reference. The revision from the tenant will be inherited if left empty.
+                  type: string
                 tenantRef:
                   description: TenantRef reference to Tenant object the cluster belongs to.
                   properties:
@@ -135,6 +141,9 @@ spec:
               type: string
             displayName:
               description: DisplayName is the display name of the tenant.
+              type: string
+            gitRepoRevision:
+              description: GitRepoRevision allows to configure the revision of the tenant configuration to use. It can be any git tree-ish reference. Defaults to HEAD if left empty.
               type: string
             gitRepoTemplate:
               description: GitRepoTemplate Template for managing the GitRepo object. If not set, no GitRepo object will be created.
@@ -195,6 +204,12 @@ spec:
               type: object
             gitRepoURL:
               description: GitRepoURL git repository storing the tenant configuration. If this is set, no gitRepoTemplate is needed.
+              type: string
+            globalGitRepoRevision:
+              description: GlobalGitRepoRevision allows to configure the revision of the global configuration to use. It can be any git tree-ish reference. Defaults to HEAD if left empty.
+              type: string
+            globalGitRepoURL:
+              description: GlobalGitRepoURL git repository storing the global configuration.
               type: string
           type: object
         status:

--- a/docs/modules/ROOT/pages/references/configuration.adoc
+++ b/docs/modules/ROOT/pages/references/configuration.adoc
@@ -37,4 +37,10 @@ Lieutenant Operator is configured via environment variables:
 |Defines with what frequency the CRs will be synced
 |5m
 
+|DEFAULT_GLOBAL_GIT_REPO_URL
+|URL of the default global configuration git repository.
+ Its value will be applied to `tenant.Spec.GlobalGitRepoURL` if not set otherwise.
+ If left empty, the `GlobalGitRepoURL` field will remain untouched.
+|
+
 |===

--- a/docs/modules/ROOT/partials/crds.html
+++ b/docs/modules/ROOT/partials/crds.html
@@ -207,6 +207,36 @@ Kubernetes core/v1.LocalObjectReference
 <tr>
 <td class="tableblock halign-left valign-top">
 <p class="tableblock">
+<code>tenantGitRepoRevision</code></br>
+<em>
+string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>TenantGitRepoRevision allows to configure the revision of the tenant configuration to use. It can be any git tree-ish reference. The revision from the tenant will be inherited if left empty.</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<code>globalGitRepoRevision</code></br>
+<em>
+string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>GlobalGitRepoRevision allows to configure the revision of the global configuration to use. It can be any git tree-ish reference. The revision from the tenant will be inherited if left empty.</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
 <code>tokenLifeTime</code></br>
 <em>
 string
@@ -372,6 +402,36 @@ Kubernetes core/v1.LocalObjectReference
 <td class="tableblock halign-left valign-top">
 <p class="tableblock">
 <p>TenantRef reference to Tenant object the cluster belongs to.</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<code>tenantGitRepoRevision</code></br>
+<em>
+string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>TenantGitRepoRevision allows to configure the revision of the tenant configuration to use. It can be any git tree-ish reference. The revision from the tenant will be inherited if left empty.</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<code>globalGitRepoRevision</code></br>
+<em>
+string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>GlobalGitRepoRevision allows to configure the revision of the global configuration to use. It can be any git tree-ish reference. The revision from the tenant will be inherited if left empty.</p>
 <p class="tableblock">
 </td>
 </tr>
@@ -1054,6 +1114,51 @@ string
 <tr>
 <td class="tableblock halign-left valign-top">
 <p class="tableblock">
+<code>gitRepoRevision</code></br>
+<em>
+string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>GitRepoRevision allows to configure the revision of the tenant configuration to use. It can be any git tree-ish reference. Defaults to HEAD if left empty.</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<code>globalGitRepoURL</code></br>
+<em>
+string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>GlobalGitRepoURL git repository storing the global configuration.</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<code>globalGitRepoRevision</code></br>
+<em>
+string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>GlobalGitRepoRevision allows to configure the revision of the global configuration to use. It can be any git tree-ish reference. Defaults to HEAD if left empty.</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
 <code>gitRepoTemplate</code></br>
 <em>
 <a href="#syn.tools/v1alpha1.GitRepoTemplate">
@@ -1173,6 +1278,51 @@ string
 <td class="tableblock halign-left valign-top">
 <p class="tableblock">
 <p>GitRepoURL git repository storing the tenant configuration. If this is set, no gitRepoTemplate is needed.</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<code>gitRepoRevision</code></br>
+<em>
+string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>GitRepoRevision allows to configure the revision of the tenant configuration to use. It can be any git tree-ish reference. Defaults to HEAD if left empty.</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<code>globalGitRepoURL</code></br>
+<em>
+string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>GlobalGitRepoURL git repository storing the global configuration.</p>
+<p class="tableblock">
+</td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<code>globalGitRepoRevision</code></br>
+<em>
+string
+</em>
+</p>
+</td>
+<td class="tableblock halign-left valign-top">
+<p class="tableblock">
+<p>GlobalGitRepoRevision allows to configure the revision of the global configuration to use. It can be any git tree-ish reference. Defaults to HEAD if left empty.</p>
 <p class="tableblock">
 </td>
 </tr>

--- a/pkg/apis/syn/v1alpha1/cluster_types.go
+++ b/pkg/apis/syn/v1alpha1/cluster_types.go
@@ -20,6 +20,10 @@ type ClusterSpec struct {
 	GitRepoTemplate *GitRepoTemplate `json:"gitRepoTemplate,omitempty"`
 	// TenantRef reference to Tenant object the cluster belongs to.
 	TenantRef corev1.LocalObjectReference `json:"tenantRef,omitempty"`
+	// TenantGitRepoRevision allows to configure the revision of the tenant configuration to use. It can be any git tree-ish reference. The revision from the tenant will be inherited if left empty.
+	TenantGitRepoRevision string `json:"tenantGitRepoRevision,omitempty"`
+	// GlobalGitRepoRevision allows to configure the revision of the global configuration to use. It can be any git tree-ish reference. The revision from the tenant will be inherited if left empty.
+	GlobalGitRepoRevision string `json:"globalGitRepoRevision,omitempty"`
 	// TokenLifetime set the token lifetime
 	TokenLifeTime string `json:"tokenLifeTime,omitempty"`
 	// Facts are key/value pairs for statically configured facts

--- a/pkg/apis/syn/v1alpha1/tenant_types.go
+++ b/pkg/apis/syn/v1alpha1/tenant_types.go
@@ -10,6 +10,12 @@ type TenantSpec struct {
 	DisplayName string `json:"displayName,omitempty"`
 	// GitRepoURL git repository storing the tenant configuration. If this is set, no gitRepoTemplate is needed.
 	GitRepoURL string `json:"gitRepoURL,omitempty"`
+	// GitRepoRevision allows to configure the revision of the tenant configuration to use. It can be any git tree-ish reference. Defaults to HEAD if left empty.
+	GitRepoRevision string `json:"gitRepoRevision,omitempty"`
+	// GlobalGitRepoURL git repository storing the global configuration.
+	GlobalGitRepoURL string `json:"globalGitRepoURL,omitempty"`
+	// GlobalGitRepoRevision allows to configure the revision of the global configuration to use. It can be any git tree-ish reference. Defaults to HEAD if left empty.
+	GlobalGitRepoRevision string `json:"globalGitRepoRevision,omitempty"`
 	// GitRepoTemplate Template for managing the GitRepo object. If not set, no GitRepo object will be created.
 	GitRepoTemplate *GitRepoTemplate `json:"gitRepoTemplate,omitempty"`
 	// DeletionPolicy defines how the external resources should be treated upon CR deletion.

--- a/pkg/controller/tenant/tenant_reconcile.go
+++ b/pkg/controller/tenant/tenant_reconcile.go
@@ -2,6 +2,7 @@ package tenant
 
 import (
 	"context"
+	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/retry"
@@ -68,6 +69,13 @@ func (r *ReconcileTenant) Reconcile(request reconcile.Request) (reconcile.Result
 				}
 			}
 		}
+
+		// Set URL of global git repo from default
+		defaultGlobalGitRepoURL := os.Getenv("DEFAULT_GLOBAL_GIT_REPO_URL")
+		if len(instance.Spec.GlobalGitRepoURL) == 0 && len(defaultGlobalGitRepoURL) > 0 {
+			instance.Spec.GlobalGitRepoURL = defaultGlobalGitRepoURL
+		}
+
 		helpers.AddDeletionProtection(instance)
 		if !equality.Semantic.DeepEqual(instanceCopy, instance) {
 			if err := r.client.Update(context.TODO(), instance); err != nil {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

https://github.com/projectsyn/commodore/issues/198 and https://github.com/projectsyn/commodore/issues/171 asks for a way to store git revisions. After discussing this with @simu  and @srueg, I opted to:

* Add a git URL for the global config repository to the tenant.
* Add revision fields for the global and the tenant config repos to both tenants and clusters.


For easier review, I have split the addition of the new fields and update of the generated resources into two separate commits. 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
