### PR TITLE
Fix error with Vault unit test

### DIFF
--- a/pkg/pipeline/vault_test.go
+++ b/pkg/pipeline/vault_test.go
@@ -75,17 +75,6 @@ var handleVaultDeletionCases = map[string]struct {
 	want synv1alpha1.DeletionPolicy
 	args args
 }{
-	"noop": {
-		want: getDefaultDeletionPolicy(),
-		args: args{
-			cluster: &synv1alpha1.Cluster{
-				Spec: synv1alpha1.ClusterSpec{
-					DeletionPolicy: getDefaultDeletionPolicy(),
-				},
-			},
-			data: &ExecutionContext{},
-		},
-	},
 	"archive": {
 		want: synv1alpha1.ArchivePolicy,
 		args: args{


### PR DESCRIPTION
We should only assert the vault client if it was actually used or else
it won't match the expected value.
    
With the use of a map instead of a slice the ordering isn't stable any-
more. There was a bug in the unit test that got triggered by that.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
