### PR TITLE
Ensure released versions don't contain "-dirty"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM docker.io/golang:1.15 as build
+ARG VERSION
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ clean:
 
 .PHONY: docker
 docker:
-	DOCKER_BUILDKIT=1 docker build -t $(IMAGE_NAME) .
+	DOCKER_BUILDKIT=1 docker build -t $(IMAGE_NAME) --build-arg VERSION="$(VERSION)" .
 	@echo built image $(IMAGE_NAME)
 
 .PHONY: lint


### PR DESCRIPTION
## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [ ] Update the ./CHANGELOG.md. NOTE is this required?

The released Docker images report their version as `<tag>-dirty`. This is due to how the version is determined during the docker build.

Since files like `Dockerfile` and `.dockerignore` are not copied into the container, `git` reports the tree status as "dirty".

This commit fixes this by injecting the actual version string from outside the build container.