### PR TITLE
Avoid reconcile loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unrelease]
+## [Unreleased]
 ### Fixed
 - Update loop for newly created GitRepos ([#130])
 
@@ -133,4 +133,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#124]: https://github.com/projectsyn/lieutenant-operator/pull/124
 [#126]: https://github.com/projectsyn/lieutenant-operator/pull/126
 [#127]: https://github.com/projectsyn/lieutenant-operator/pull/127
-[#120]: https://github.com/projectsyn/lieutenant-operator/pull/130
+[#130]: https://github.com/projectsyn/lieutenant-operator/pull/130

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unrelease]
+### Fixed
+- Update loop for newly created GitRepos ([#130])
+
 ## [v0.4.1] - 2020-11-05
 ### Changed
 - Redesigned reconcile handling ([#120])
@@ -129,3 +133,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#124]: https://github.com/projectsyn/lieutenant-operator/pull/124
 [#126]: https://github.com/projectsyn/lieutenant-operator/pull/126
 [#127]: https://github.com/projectsyn/lieutenant-operator/pull/127
+[#120]: https://github.com/projectsyn/lieutenant-operator/pull/130

--- a/pkg/apis/syn/v1alpha1/cluster_types.go
+++ b/pkg/apis/syn/v1alpha1/cluster_types.go
@@ -107,3 +107,11 @@ func (c *Cluster) SetGitRepoURLAndHostKeys(URL, hostKeys string) {
 	c.Spec.GitRepoURL = URL
 	c.Spec.GitHostKeys = hostKeys
 }
+
+func (c *Cluster) GetSpec() interface{} {
+	return c.Spec
+}
+
+func (c *Cluster) GetStatus() interface{} {
+	return c.Status
+}

--- a/pkg/apis/syn/v1alpha1/gitrepo_types.go
+++ b/pkg/apis/syn/v1alpha1/gitrepo_types.go
@@ -155,3 +155,11 @@ func (g *GitRepo) GetDisplayName() string {
 func (g *GitRepo) SetGitRepoURLAndHostKeys(URL, hostKeys string) {
 	//NOOP
 }
+
+func (g *GitRepo) GetSpec() interface{} {
+	return g.Spec
+}
+
+func (g *GitRepo) GetStatus() interface{} {
+	return g.Status
+}

--- a/pkg/apis/syn/v1alpha1/tenant_types.go
+++ b/pkg/apis/syn/v1alpha1/tenant_types.go
@@ -91,3 +91,11 @@ func (t *Tenant) GetDisplayName() string {
 func (t *Tenant) SetGitRepoURLAndHostKeys(URL, hostKeys string) {
 	t.Spec.GitRepoURL = URL
 }
+
+func (t *Tenant) GetSpec() interface{} {
+	return t.Spec
+}
+
+func (t *Tenant) GetStatus() interface{} {
+	return t.Status
+}

--- a/pkg/controller/cluster/cluster_reconcile.go
+++ b/pkg/controller/cluster/cluster_reconcile.go
@@ -37,6 +37,8 @@ func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Resul
 		FinalizerName: finalizerName,
 	}
 
-	return reconcile.Result{}, pipeline.ReconcileCluster(instance, data)
+	res := pipeline.ReconcileCluster(instance, data)
+
+	return reconcile.Result{Requeue: res.Requeue}, res.Err
 
 }

--- a/pkg/controller/gitrepo/gitrepo_reconcile.go
+++ b/pkg/controller/gitrepo/gitrepo_reconcile.go
@@ -40,6 +40,8 @@ func (r *ReconcileGitRepo) Reconcile(request reconcile.Request) (reconcile.Resul
 		FinalizerName: finalizerName,
 	}
 
-	return reconcile.Result{}, pipeline.ReconcileGitRep(instance, data)
+	res := pipeline.ReconcileGitRep(instance, data)
+
+	return reconcile.Result{Requeue: res.Requeue}, res.Err
 
 }

--- a/pkg/controller/tenant/tenant_reconcile.go
+++ b/pkg/controller/tenant/tenant_reconcile.go
@@ -32,5 +32,7 @@ func (r *ReconcileTenant) Reconcile(request reconcile.Request) (reconcile.Result
 		FinalizerName: "",
 	}
 
-	return reconcile.Result{}, pipeline.ReconcileTenant(instance, data)
+	res := pipeline.ReconcileTenant(instance, data)
+
+	return reconcile.Result{Requeue: res.Requeue}, res.Err
 }

--- a/pkg/pipeline/cluster.go
+++ b/pkg/pipeline/cluster.go
@@ -17,7 +17,5 @@ func clusterSpecificSteps(obj PipelineObject, data *ExecutionContext) ExecutionR
 		{Name: "apply tenant template", F: applyTenantTemplate},
 	}
 
-	err := RunPipeline(obj, data, steps)
-
-	return ExecutionResult{Err: err}
+	return RunPipeline(obj, data, steps)
 }

--- a/pkg/pipeline/common.go
+++ b/pkg/pipeline/common.go
@@ -16,7 +16,5 @@ func common(obj PipelineObject, data *ExecutionContext) ExecutionResult {
 		{Name: "update object", F: updateObject},
 	}
 
-	err := RunPipeline(obj, data, steps)
-
-	return ExecutionResult{Err: err}
+	return RunPipeline(obj, data, steps)
 }

--- a/pkg/pipeline/common_steps.go
+++ b/pkg/pipeline/common_steps.go
@@ -95,9 +95,6 @@ func updateObject(obj PipelineObject, data *ExecutionContext) ExecutionResult {
 
 		err := data.Client.Status().Patch(context.TODO(), rtObj, client.MergeFrom(origRtObj))
 		if err != nil {
-			if k8serrors.IsConflict(err) {
-				return ExecutionResult{Abort: true}
-			}
 			return ExecutionResult{Err: err}
 		}
 	}

--- a/pkg/pipeline/common_steps.go
+++ b/pkg/pipeline/common_steps.go
@@ -82,7 +82,7 @@ func updateObject(obj PipelineObject, data *ExecutionContext) ExecutionResult {
 		err := data.Client.Update(context.TODO(), rtObj)
 		if err != nil {
 			if k8serrors.IsConflict(err) {
-				return ExecutionResult{Abort: true}
+				return ExecutionResult{Requeue: true}
 			}
 			return ExecutionResult{Err: err}
 		}
@@ -93,7 +93,7 @@ func updateObject(obj PipelineObject, data *ExecutionContext) ExecutionResult {
 		err := data.Client.Status().Update(context.TODO(), rtObj)
 		if err != nil {
 			if k8serrors.IsConflict(err) {
-				return ExecutionResult{Abort: true}
+				return ExecutionResult{Requeue: true}
 			}
 			return ExecutionResult{Err: err}
 		}

--- a/pkg/pipeline/common_steps_test.go
+++ b/pkg/pipeline/common_steps_test.go
@@ -271,7 +271,13 @@ func Test_handleFinalizer(t *testing.T) {
 var updateObjectCases = genericCases{
 	"update objects": {
 		args: args{
-			data: &ExecutionContext{},
+			data: &ExecutionContext{
+				originalObject: &synv1alpha1.Tenant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
 			tenant: &synv1alpha1.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
@@ -281,7 +287,13 @@ var updateObjectCases = genericCases{
 	},
 	"update fail": {
 		args: args{
-			data:   &ExecutionContext{},
+			data: &ExecutionContext{
+				originalObject: &synv1alpha1.Tenant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			},
 			tenant: &synv1alpha1.Tenant{},
 		},
 	},

--- a/pkg/pipeline/common_steps_test.go
+++ b/pkg/pipeline/common_steps_test.go
@@ -331,4 +331,5 @@ func Test_updateObjectStatus(t *testing.T) {
 
 	assert.NotNil(t, updatedCluster.Status.BootstrapToken)
 	assert.Equal(t, "token-1234", updatedCluster.Status.BootstrapToken.Token)
+	assert.NotEqual(t, updatedCluster.ResourceVersion, cluster.GetResourceVersion())
 }

--- a/pkg/pipeline/common_steps_test.go
+++ b/pkg/pipeline/common_steps_test.go
@@ -314,7 +314,14 @@ func Test_updateObject(t *testing.T) {
 }
 
 func Test_updateObjectStatus(t *testing.T) {
-	ex := &ExecutionContext{}
+	ex := &ExecutionContext{
+		originalObject: &synv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "cluster-a",
+				ResourceVersion: "1234",
+			},
+		},
+	}
 	cluster := &synv1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "cluster-a",

--- a/pkg/pipeline/pipelines.go
+++ b/pkg/pipeline/pipelines.go
@@ -12,6 +12,7 @@ type Step struct {
 
 func ReconcileTenant(obj PipelineObject, data *ExecutionContext) error {
 	steps := []Step{
+		{Name: "copy original object", F: deepCopyOriginal},
 		{Name: "tenant specific steps", F: tenantSpecificSteps},
 		{Name: "create git repo", F: createGitRepo},
 		{Name: "set gitrepo url and hostkeys", F: setGitRepoURLAndHostKeys},
@@ -23,6 +24,7 @@ func ReconcileTenant(obj PipelineObject, data *ExecutionContext) error {
 
 func ReconcileCluster(obj PipelineObject, data *ExecutionContext) error {
 	steps := []Step{
+		{Name: "copy original object", F: deepCopyOriginal},
 		{Name: "cluster specific steps", F: clusterSpecificSteps},
 		{Name: "create git repo", F: createGitRepo},
 		{Name: "set gitrepo url and hostkeys", F: setGitRepoURLAndHostKeys},
@@ -35,6 +37,7 @@ func ReconcileCluster(obj PipelineObject, data *ExecutionContext) error {
 
 func ReconcileGitRep(obj PipelineObject, data *ExecutionContext) error {
 	steps := []Step{
+		{Name: "copy original object", F: deepCopyOriginal},
 		{Name: "deletion check", F: checkIfDeleted},
 		{Name: "git repo specific steps", F: gitRepoSpecificSteps},
 		{Name: "add tenant label", F: addTenantLabel},

--- a/pkg/pipeline/reconcile_types.go
+++ b/pkg/pipeline/reconcile_types.go
@@ -18,14 +18,17 @@ type PipelineObject interface {
 	GetDeletionPolicy() synv1alpha1.DeletionPolicy
 	GetDisplayName() string
 	SetGitRepoURLAndHostKeys(URL, hostKeys string)
+	GetSpec() interface{}
+	GetStatus() interface{}
 }
 
 // ExecutionContext contains additional data about the CRD bein processed.
 type ExecutionContext struct {
-	FinalizerName string
-	Client        client.Client
-	Log           logr.Logger
-	Deleted       bool
+	FinalizerName  string
+	Client         client.Client
+	Log            logr.Logger
+	Deleted        bool
+	originalObject PipelineObject
 }
 
 // ExecutionResult indicates wether the current execution should be aborted and

--- a/pkg/pipeline/reconcile_types.go
+++ b/pkg/pipeline/reconcile_types.go
@@ -34,6 +34,7 @@ type ExecutionContext struct {
 // ExecutionResult indicates wether the current execution should be aborted and
 // if there was an error.
 type ExecutionResult struct {
-	Abort bool
-	Err   error
+	Abort   bool
+	Err     error
+	Requeue bool
 }

--- a/pkg/pipeline/tenant.go
+++ b/pkg/pipeline/tenant.go
@@ -13,7 +13,5 @@ func tenantSpecificSteps(obj PipelineObject, data *ExecutionContext) ExecutionRe
 		{Name: "set global git repo url", F: setGlobalGitRepoURL},
 	}
 
-	err := RunPipeline(obj, data, steps)
-
-	return ExecutionResult{Err: err}
+	return RunPipeline(obj, data, steps)
 }


### PR DESCRIPTION
The previous implementation caused the CRs to be updated with each
reconcile. Although no actual changes were applied the ResourceVersion
increased every time. This lead to the status not being set correctly.
And of course excessive reconciling.

By uptdating the status first and catching conflicts, we can avoid that.
This bug was only triggered for newly created GitRepos.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
