### PR TITLE
Remove usage of `::set-env` in GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set version latest
         if: github.ref == 'refs/heads/master'
-        run: echo ::set-env name=VERSION::latest
+        run: echo "VERSION=latest" >> $GITHUB_ENV
       - name: Set version from tag
         if: startsWith(github.ref, 'refs/tags/v')
-        run: echo ::set-env name=VERSION::$(echo ${GITHUB_REF#refs/tags/})
+        run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_ENV
       - name: Build Image
         run: make docker
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         run: echo "VERSION=latest" >> $GITHUB_ENV
       - name: Set version from tag
         if: startsWith(github.ref, 'refs/tags/v')
-        run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Build Image
         run: make docker
         env:


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
