### PR TITLE
Grant more permissions on roles and rolebindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.5.1] - 2021-02-16
+### Fixed
+- Add missing RBAC permissions to modify Roles and RoleBindings ([#152])
+
 ## [v0.5.0] - 2021-02-11
 ### Added
 - Template for tenants ([#138])
-- Per tenant access to tenant and cluster objects [(#140)]
+- Per tenant access to tenant and cluster objects ([#140])
 
 ## [v0.4.2] - 2020-11-11
 ### Fixed
@@ -145,3 +149,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#133]: https://github.com/projectsyn/lieutenant-operator/pull/133
 [#138]: https://github.com/projectsyn/lieutenant-operator/pull/138
 [#140]: https://github.com/projectsyn/lieutenant-operator/pull/140
+[#152]: https://github.com/projectsyn/lieutenant-operator/pull/152

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -51,8 +51,12 @@ rules:
       - roles
       - rolebindings
     verbs:
-      - get
       - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
   - apiGroups:
       - apps
     resourceNames:


### PR DESCRIPTION
Since #140, the operator needs more permissions for role and
rolebindings. This change adds them to the deployment file.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
