### PR TITLE
Fix Docker image name in Makefile vars

### DIFF
--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -31,7 +31,7 @@ INTEGRATION_TEST_DEBUG_OUTPUT ?= false
 KUSTOMIZE ?= go run sigs.k8s.io/kustomize/kustomize/v3
 
 # Image URL to use all building/pushing image targets
-DOCKER_IMG ?= docker.io/projectsyn/lieutenant:$(IMG_TAG)
-QUAY_IMG ?= quay.io/projectsyn/lieutenant:$(IMG_TAG)
+DOCKER_IMG ?= docker.io/projectsyn/lieutenant-operator:$(IMG_TAG)
+QUAY_IMG ?= quay.io/projectsyn/lieutenant-operator:$(IMG_TAG)
 
 testbin_created = $(TESTBIN_DIR)/.created


### PR DESCRIPTION
The Docker image `projectsyn/lieutenant` was not able to be pushed to quay.io, because it should have been called `projectsyn/lieutenant-operator`. Interestingly, it was pushed to Docker Hub as https://hub.docker.com/r/projectsyn/lieutenant.

This should be cleaned up once this PR is merged.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
