### PR TITLE
Add details about where errors occurred

### DIFF
--- a/controllers/cluster/bootstrap_token.go
+++ b/controllers/cluster/bootstrap_token.go
@@ -21,7 +21,7 @@ func setBootstrapToken(obj pipeline.Object, data *pipeline.Context) pipeline.Res
 		data.Log.Info("Adding status to Cluster object")
 		err := newClusterStatus(instance)
 		if err != nil {
-			return pipeline.Result{Err: err}
+			return pipeline.Result{Err: fmt.Errorf("setting initial status on cluster: %w", err)}
 		}
 	}
 

--- a/controllers/cluster/tenant.go
+++ b/controllers/cluster/tenant.go
@@ -15,7 +15,7 @@ func setTenantOwner(obj pipeline.Object, data *pipeline.Context) pipeline.Result
 
 	err := data.Client.Get(data.Context, tenantName, tenant)
 	if err != nil {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("get tenant: %w", err)}
 	}
 
 	obj.SetOwnerReferences([]metav1.OwnerReference{
@@ -39,7 +39,7 @@ func applyClusterTemplateFromTenant(obj pipeline.Object, data *pipeline.Context)
 	}
 
 	if err := applyClusterTemplate(instance, tenant); err != nil {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("apply cluster template: %w", err)}
 	}
 	return pipeline.Result{}
 }

--- a/controllers/gitrepo/steps.go
+++ b/controllers/gitrepo/steps.go
@@ -21,7 +21,7 @@ func Steps(obj pipeline.Object, data *pipeline.Context) pipeline.Result {
 
 	err := fetchGitRepoTemplate(instance, data)
 	if err != nil {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("fetch Git repo template: %w", err)}
 	}
 
 	if instance.Spec.RepoType == synv1alpha1.UnmanagedRepoType {
@@ -31,7 +31,7 @@ func Steps(obj pipeline.Object, data *pipeline.Context) pipeline.Result {
 
 	repo, hostKeys, err := manager.GetGitClient(data.Context, &instance.Spec.GitRepoTemplate, instance.GetNamespace(), data.Log, data.Client)
 	if err != nil {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("get Git client: %w", err)}
 	}
 
 	instance.Status.HostKeys = hostKeys
@@ -49,7 +49,7 @@ func Steps(obj pipeline.Object, data *pipeline.Context) pipeline.Result {
 	if data.Deleted {
 		err := repo.Remove()
 		if err != nil {
-			return pipeline.Result{Err: err}
+			return pipeline.Result{Err: fmt.Errorf("remove repo: %w", err)}
 		}
 		return pipeline.Result{}
 	}
@@ -61,7 +61,7 @@ func Steps(obj pipeline.Object, data *pipeline.Context) pipeline.Result {
 
 	changed, err := repo.Update()
 	if err != nil {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("update repo: %w", err)}
 	}
 
 	if changed {

--- a/controllers/gitrepo/utils.go
+++ b/controllers/gitrepo/utils.go
@@ -90,7 +90,7 @@ func UpdateURLAndHostKeys(obj pipeline.Object, data *pipeline.Context) pipeline.
 		if errors.IsNotFound(err) {
 			return pipeline.Result{}
 		}
-		return pipeline.Result{Abort: true, Err: err}
+		return pipeline.Result{Abort: true, Err: fmt.Errorf("get gitrepo: %w", err)}
 	}
 
 	if gitRepo.Spec.RepoType != synv1alpha1.UnmanagedRepoType {

--- a/controllers/tenant/git.go
+++ b/controllers/tenant/git.go
@@ -37,7 +37,7 @@ func updateTenantGitRepo(obj pipeline.Object, data *pipeline.Context) pipeline.R
 
 	err := data.Client.List(data.Context, clusterList, listOptions)
 	if err != nil {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("list clusters: %w", err)}
 	}
 
 	for _, cluster := range clusterList.Items {

--- a/controllers/tenant/role.go
+++ b/controllers/tenant/role.go
@@ -27,7 +27,7 @@ func createRole(obj pipeline.Object, data *pipeline.Context) pipeline.Result {
 
 	err = data.Client.Create(data.Context, role)
 	if err != nil && !errors.IsAlreadyExists(err) {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("create role: %w", err)}
 	}
 
 	return pipeline.Result{}

--- a/controllers/tenant/role_binding.go
+++ b/controllers/tenant/role_binding.go
@@ -25,7 +25,7 @@ func createRoleBinding(obj pipeline.Object, data *pipeline.Context) pipeline.Res
 
 	err = data.Client.Create(data.Context, binding)
 	if err != nil && !errors.IsAlreadyExists(err) {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("create rolebinding: %w", err)}
 	}
 
 	return pipeline.Result{}

--- a/controllers/tenant/service_account.go
+++ b/controllers/tenant/service_account.go
@@ -25,7 +25,7 @@ func createServiceAccount(obj pipeline.Object, data *pipeline.Context) pipeline.
 
 	err = data.Client.Create(data.Context, sa)
 	if err != nil && !errors.IsAlreadyExists(err) {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("create serviceaccount: %w", err)}
 	}
 
 	return pipeline.Result{}

--- a/controllers/tenant/template.go
+++ b/controllers/tenant/template.go
@@ -32,7 +32,7 @@ func applyTemplateFromTenantTemplate(obj pipeline.Object, data *pipeline.Context
 	}
 
 	if err := tenant.ApplyTemplate(template); err != nil {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("apply tenant template: %w", err)}
 	}
 
 	return pipeline.Result{}

--- a/pipeline/steps.go
+++ b/pipeline/steps.go
@@ -89,7 +89,7 @@ func updateObject(obj Object, data *Context) Result {
 				data.Log.V(1).Error(err, "conflict while updating object; requeueing")
 				return Result{Requeue: true}
 			}
-			return Result{Err: err}
+			return Result{Err: fmt.Errorf("update %s/%s: %w", obj.GroupVersionKind().String(), obj.GetName(), err)}
 		}
 	}
 
@@ -105,7 +105,7 @@ func updateObject(obj Object, data *Context) Result {
 				data.Log.V(1).Error(err, "conflict while updating object; requeueing")
 				return Result{Requeue: true}
 			}
-			return Result{Err: err}
+			return Result{Err: fmt.Errorf("update %s/%s status: %w", obj.GroupVersionKind().String(), obj.GetName(), err)}
 		}
 	}
 

--- a/vault/reconcile_steps.go
+++ b/vault/reconcile_steps.go
@@ -32,17 +32,17 @@ func CreateOrUpdateVault(obj pipeline.Object, data *pipeline.Context) pipeline.R
 
 	token, err := GetServiceAccountToken(obj, data)
 	if err != nil {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("get SA token: %w", err)}
 	}
 
 	vaultClient, err := getVaultClient(obj, data)
 	if err != nil {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("get vault client: %w", err)}
 	}
 
 	err = vaultClient.AddSecrets([]VaultSecret{{Path: secretPath, Value: token}})
 	if err != nil {
-		return pipeline.Result{Err: err}
+		return pipeline.Result{Err: fmt.Errorf("add vault secret '%s': %w", secretPath, err)}
 	}
 
 	return pipeline.Result{}
@@ -93,11 +93,11 @@ func HandleVaultDeletion(obj pipeline.Object, data *pipeline.Context) pipeline.R
 	if data.Deleted {
 		vaultClient, err := getVaultClient(obj, data)
 		if err != nil {
-			return pipeline.Result{Err: err}
+			return pipeline.Result{Err: fmt.Errorf("get vault client: %w", err)}
 		}
 		err = vaultClient.RemoveSecrets([]VaultSecret{{Path: path.Dir(secretPath), Value: ""}})
 		if err != nil {
-			return pipeline.Result{Err: err}
+			return pipeline.Result{Err: fmt.Errorf("remove secret: %w", err)}
 		}
 	}
 	return pipeline.Result{}


### PR DESCRIPTION
During troubleshooting issues with Lieutenant, we noticed that some
error messages did not contain enough information to find out which step
of a pipeline failed.

This commit tries to improve the errors reported back to the user by
making sure all errors returned in a `Result` contain some information
about the precise step that triggered it.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] ~Update the documentation.~
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] ~Link this PR to related issues.~
