### PR TITLE
Register Gitlab implemenation

### DIFF
--- a/controllers/gitrepo/steps.go
+++ b/controllers/gitrepo/steps.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 
 	synv1alpha1 "github.com/projectsyn/lieutenant-operator/api/v1alpha1"
+
+	// Register Gitrepo implementation - DONOT REMOVE
+	_ "github.com/projectsyn/lieutenant-operator/git"
 	"github.com/projectsyn/lieutenant-operator/git/manager"
 	"github.com/projectsyn/lieutenant-operator/pipeline"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

During refactor we seem to have lost the import that registered the Gitlab implementation.  This lead to all gitrepo reconciles to fail. This PR will add back this magic import.

I personally really don't like the magic `init` approach, as we have seen these imports can easily be missed when refactoring.
But I would say changing this is out of scope for this bugfix.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
