### PR TITLE
Allow `controller-manager` to `list`, `get`, and `watch` TenantTemplates

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -120,3 +120,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - syn.tools
+  resources:
+  - tenanttemplates
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/tenant_controller.go
+++ b/controllers/tenant_controller.go
@@ -25,6 +25,7 @@ type TenantReconciler struct {
 //+kubebuilder:rbac:groups=syn.tools,resources=tenants,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=syn.tools,resources=tenants/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=syn.tools,resources=tenants/finalizers,verbs=update
+//+kubebuilder:rbac:groups=syn.tools,resources=tenanttemplates,verbs=get;list;watch
 
 // Reconcile The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

This PR allows the `controller-manager` to `list`, `get` and `watch` TenantTemplates.

This fixes the log i've seen on lieutenant-dev:

```
E0809 15:10:15.392088       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.2/tools/cache/reflector.go:167: Failed to watch *v1alpha1.TenantTemplate: failed to list *v1alpha1.TenantTemplate: tenanttemplates.syn.tools is forbidden: User "system:serviceaccount:lieutenant-dev:lieutenant-dev-lieutenant-operator" cannot list resource "tenanttemplates" in API group "syn.tools" in the namespace "lieutenant-dev"
```

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
