### PR TITLE
Fix typed nil assignment

### DIFF
--- a/vault/client.go
+++ b/vault/client.go
@@ -53,11 +53,13 @@ func NewClient(deletionPolicy synv1alpha1.DeletionPolicy, log logr.Logger) (Vaul
 		return instanceClient, nil
 	}
 
-	var err error
-	instanceClient, err = newBankVaultClient(deletionPolicy, log)
+	c, err := newBankVaultClient(deletionPolicy, log)
+	if err != nil {
+		return nil, err
+	}
+	instanceClient = c
 
-	return instanceClient, err
-
+	return instanceClient, nil
 }
 
 // SetCustomClient is used if a custom client needs to be used. Currently only


### PR DESCRIPTION
The newBankVaultClient function returns a typed nil on error. This will cause subsequent calls to panic if we assign it directly to the global variable.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
