### PR TITLE
Adds recursive deletion of directories

### DIFF
--- a/vault/client.go
+++ b/vault/client.go
@@ -178,8 +178,7 @@ func (b *BankVaultClient) removeSecret(removeSecret VaultSecret) error {
 	for _, secret := range secrets {
 		if isDirectory(secret) {
 			err := b.removeSecret(VaultSecret{
-				Path:  path.Join(removeSecret.Path, secret),
-				Value: "",
+				Path: path.Join(removeSecret.Path, secret),
 			})
 			if err != nil {
 				return err

--- a/vault/client_test.go
+++ b/vault/client_test.go
@@ -248,7 +248,27 @@ func getVersionHTTPServer() *httptest.Server {
 	mux.HandleFunc("/v1/kv/delete/kv2/test/foo", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+	mux.HandleFunc("/v1/kv/delete/kv2/test/bar", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"errors":[]}`)
+	})
+	mux.HandleFunc("/v1/kv/delete/kv2/test/bar/buzz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
 
+	mux.HandleFunc("/v1/kv/metadata/kv2/test/bar", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("list") == "true" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+				"data": {
+				  "keys": ["buzz"]
+				}
+			  }`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"errors":[]}`)
+	})
 	mux.HandleFunc("/v1/kv/metadata/kv2/test/foo", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		versionBody := `
@@ -280,6 +300,27 @@ func getVersionHTTPServer() *httptest.Server {
 		  }`
 		_, _ = io.WriteString(w, versionBody)
 	})
+	mux.HandleFunc("/v1/kv/metadata/kv2/test/bar/buzz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		versionBody := `
+		{
+			"data": {
+			  "created_time": "2018-03-22T02:24:06.945319214Z",
+			  "current_version": 1,
+			  "max_versions": 0,
+			  "oldest_version": 0,
+			  "updated_time": "2018-03-22T02:36:43.986212308Z",
+			  "versions": {
+				"1": {
+				  "created_time": "2018-03-22T02:24:06.945319214Z",
+				  "deletion_time": "",
+				  "destroyed": false
+				}
+			  }
+			}
+		}`
+		_, _ = io.WriteString(w, versionBody)
+	})
 
 	mux.HandleFunc("/v1/kv/metadata/kv2/test", func(w http.ResponseWriter, r *http.Request) {
 
@@ -288,7 +329,7 @@ func getVersionHTTPServer() *httptest.Server {
 		if r.URL.Query().Get("list") == "true" {
 			_, _ = io.WriteString(w, `{
 				"data": {
-				  "keys": ["foo", "foo/"]
+				  "keys": ["foo", "bar/"]
 				}
 			  }`)
 			return


### PR DESCRIPTION
Currently we panic during deletion if the cluster vault directory contains another directory. This is the case for example when following the [exoscale setup.](https://kb.vshn.ch/oc4/how-tos/exoscale/install.html#_set_secrets_in_vault)

This commit fixes this by recursively deleting all sub-directories. This should be the intended behavior of `removeSecret` anyway?

The one question I still have if deleting all secrets in the clusters directory is the intended behavior of `HandleVaultDeletion`
https://github.com/projectsyn/lieutenant-operator/blob/35c1bf7a5e6418e4db13c0aa4f5820399e8e2415/vault/reconcile_steps.go#L87-L100

At first sight this looks like it only deletes the `steward` secret, but it deletes all secrets of this cluster.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
Closes #183 