### PR TITLE
Fix error when recreating git repository

### DIFF
--- a/git/gitlab/gitlab.go
+++ b/git/gitlab/gitlab.go
@@ -350,6 +350,7 @@ func (g *Gitlab) CommitTemplateFiles() error {
 	co := g.getCommitOptions()
 
 	for _, file := range filesToCommit {
+		file := file // Make a copy so we can savely reference the file
 		var fileAction gitlab.FileActionValue
 		if file.Delete {
 			g.log.Info("deleting file from repository", "file", file.FileName, "repository", g.project.Name)
@@ -398,10 +399,12 @@ func (g *Gitlab) compareFiles() ([]manager.CommitFile, error) {
 			if strings.Contains(err.Error(), "Tree Not Found") {
 
 				for name, content := range g.ops.TemplateFiles {
-					files = append(files, manager.CommitFile{
-						FileName: name,
-						Content:  content,
-					})
+					if content != manager.DeletionMagicString {
+						files = append(files, manager.CommitFile{
+							FileName: name,
+							Content:  content,
+						})
+					}
 				}
 
 				return files, nil


### PR DESCRIPTION
We fix two bugs in this PR

* When creating (or recreating) a repository we will create a file containing `{delete}` for all deleted class files.
* When adding more than one file we try to create the last file multiple times because of a pointer error

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
