### PR TITLE
Fix issue that blocked status updates

### DIFF
--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -112,6 +112,10 @@ func (c *Cluster) GetSpec() interface{} {
 	return c.Spec
 }
 
+func (c *Cluster) GetMeta() metav1.ObjectMeta {
+	return c.ObjectMeta
+}
+
 func (c *Cluster) GetStatus() interface{} {
 	return c.Status
 }

--- a/api/v1alpha1/gitrepo_types.go
+++ b/api/v1alpha1/gitrepo_types.go
@@ -160,6 +160,10 @@ func (g *GitRepo) GetSpec() interface{} {
 	return g.Spec
 }
 
+func (g *GitRepo) GetMeta() metav1.ObjectMeta {
+	return g.ObjectMeta
+}
+
 func (g *GitRepo) GetStatus() interface{} {
 	return g.Status
 }

--- a/api/v1alpha1/tenant_types.go
+++ b/api/v1alpha1/tenant_types.go
@@ -99,6 +99,10 @@ func (t *Tenant) GetSpec() interface{} {
 	return t.Spec
 }
 
+func (t *Tenant) GetMeta() metav1.ObjectMeta {
+	return t.ObjectMeta
+}
+
 func (t *Tenant) GetStatus() interface{} {
 	return t.Status
 }

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-logr/logr"
 	synv1alpha1 "github.com/projectsyn/lieutenant-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -26,6 +27,7 @@ type Object interface {
 	GetDeletionPolicy() synv1alpha1.DeletionPolicy
 	GetDisplayName() string
 	SetGitRepoURLAndHostKeys(URL, hostKeys string)
+	GetMeta() metav1.ObjectMeta
 	GetSpec() interface{}
 	GetStatus() interface{}
 }
@@ -57,7 +59,7 @@ type Step struct {
 }
 
 func RunPipeline(obj Object, data *Context, steps []Step) Result {
-	l := data.Log.V(2).WithName("RunPipeline")
+	l := data.Log.V(7).WithName("RunPipeline")
 	l.Info("running steps", "steps", stepNames(steps))
 
 	for i, step := range steps {


### PR DESCRIPTION
Update on the main resource does not update the status, but it does fetch the current version of that status from k8s. We currently use the orginal object in this update call, which has its status overwritten.  We need to copy the resource when updating to make sure that we can update both the resource and  its status.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
