### PR TITLE
Fix git repository race condition

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -50,7 +50,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 	steps := []pipeline.Step{
 		{Name: "copy original object", F: pipeline.DeepCopyOriginal},
 		{Name: "cluster specific steps", F: cluster.SpecificSteps},
-		{Name: "create git repo", F: gitrepo.Create},
+		{Name: "create git repo", F: gitrepo.CreateOrUpdate},
 		{Name: "set gitrepo url and hostkeys", F: gitrepo.UpdateURLAndHostKeys},
 		{Name: "add tenant label", F: pipeline.AddTenantLabel},
 		{Name: "Common", F: pipeline.Common},

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -65,5 +65,6 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&synv1alpha1.Cluster{}).
+		Owns(&synv1alpha1.GitRepo{}).
 		Complete(r)
 }

--- a/controllers/tenant_controller.go
+++ b/controllers/tenant_controller.go
@@ -66,5 +66,6 @@ func (r *TenantReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&synv1alpha1.Tenant{}).
+		Owns(&synv1alpha1.GitRepo{}).
 		Complete(r)
 }

--- a/controllers/tenant_controller.go
+++ b/controllers/tenant_controller.go
@@ -67,5 +67,6 @@ func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&synv1alpha1.Tenant{}).
 		Owns(&synv1alpha1.GitRepo{}).
+		Owns(&synv1alpha1.Cluster{}).
 		Complete(r)
 }

--- a/controllers/tenant_controller.go
+++ b/controllers/tenant_controller.go
@@ -53,7 +53,7 @@ func (r *TenantReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	steps := []pipeline.Step{
 		{Name: "copy original object", F: pipeline.DeepCopyOriginal},
 		{Name: "tenant specific steps", F: tenant.Steps},
-		{Name: "create git repo", F: gitrepo.Create},
+		{Name: "create git repo", F: gitrepo.CreateOrUpdate},
 		{Name: "set gitrepo url and hostkeys", F: gitrepo.UpdateURLAndHostKeys},
 		{Name: "common", F: pipeline.Common},
 	}


### PR DESCRIPTION
There are currently two race conditions:

* Cluster / Tenant resources fetch the Git repo URL from the gitrepo resource but are not reconciled on its change
* Git repo resources fetch GitRepoTemplate from Cluster / Tenant but are not reconciled on their change.
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->

closes #203 