### PR TITLE
Fix recreated service account token bug

### DIFF
--- a/controllers/cluster/rbac.go
+++ b/controllers/cluster/rbac.go
@@ -1,10 +1,13 @@
 package cluster
 
 import (
+	"context"
+
 	synv1alpha1 "github.com/projectsyn/lieutenant-operator/api/v1alpha1"
 	"github.com/projectsyn/lieutenant-operator/pipeline"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,42 +19,81 @@ func createClusterRBAC(obj pipeline.Object, data *pipeline.Context) pipeline.Res
 		Namespace:       obj.GetNamespace(),
 		OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(obj, synv1alpha1.SchemeBuilder.GroupVersion.WithKind("Cluster"))},
 	}
-	serviceAccount := &corev1.ServiceAccount{ObjectMeta: objMeta}
+	if err := createClusterSA(data.Context, data.Client, objMeta); err != nil {
+		return pipeline.Result{Err: err}
+	}
+	if err := createOrUpdateClusterRole(data.Context, data.Client, objMeta); err != nil {
+		return pipeline.Result{Err: err}
+	}
+	if err := createOrUpdateClusterRoleBinding(data.Context, data.Client, objMeta); err != nil {
+		return pipeline.Result{Err: err}
+	}
+
+	return pipeline.Result{}
+}
+
+func createClusterSA(ctx context.Context, c client.Client, objMeta metav1.ObjectMeta) error {
+	sa := &corev1.ServiceAccount{ObjectMeta: objMeta}
+	if err := c.Create(ctx, sa); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+func createOrUpdateClusterRole(ctx context.Context, c client.Client, objMeta metav1.ObjectMeta) error {
 	role := &rbacv1.Role{
 		ObjectMeta: objMeta,
 		Rules: []rbacv1.PolicyRule{{
 			APIGroups:     []string{synv1alpha1.GroupVersion.Group},
 			Resources:     []string{"clusters", "clusters/status"},
 			Verbs:         []string{"get", "update"},
-			ResourceNames: []string{obj.GetName()},
+			ResourceNames: []string{objMeta.Name},
 		}},
 	}
+	found := &rbacv1.Role{}
+
+	err := c.Get(ctx, client.ObjectKeyFromObject(role), found)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			err = c.Create(ctx, role)
+		}
+		return err
+	}
+	if !equality.Semantic.DeepEqual(found.Rules, role.Rules) {
+		found.Rules = role.Rules
+		return c.Update(ctx, found)
+	}
+	return nil
+}
+
+func createOrUpdateClusterRoleBinding(ctx context.Context, c client.Client, objMeta metav1.ObjectMeta) error {
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: objMeta,
 		RoleRef: rbacv1.RoleRef{
 			Kind: "Role",
-			Name: role.Name,
+			Name: objMeta.Name,
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind:      "ServiceAccount",
-			Name:      serviceAccount.Name,
-			Namespace: serviceAccount.Namespace,
+			Name:      objMeta.Name,
+			Namespace: objMeta.Namespace,
 		}},
 	}
-	for _, item := range []client.Object{serviceAccount, role, roleBinding} {
-		found := item.DeepCopyObject().(client.Object)
-		err := data.Client.Get(data.Context, client.ObjectKeyFromObject(item), found)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				if err := data.Client.Create(data.Context, item); err != nil && !errors.IsAlreadyExists(err) {
-					return pipeline.Result{Err: err}
-				}
-			}
-			return pipeline.Result{Err: err}
+	found := &rbacv1.RoleBinding{}
+
+	err := c.Get(ctx, client.ObjectKeyFromObject(roleBinding), found)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			err = c.Create(ctx, roleBinding)
 		}
-		if err := data.Client.Update(data.Context, item); err != nil {
-			return pipeline.Result{Err: err}
-		}
+		return err
 	}
-	return pipeline.Result{}
+
+	if !equality.Semantic.DeepEqual(found.RoleRef, roleBinding.RoleRef) ||
+		!equality.Semantic.DeepEqual(found.Subjects, roleBinding.Subjects) {
+		found.RoleRef = roleBinding.RoleRef
+		found.Subjects = roleBinding.Subjects
+		return c.Update(ctx, found)
+	}
+	return nil
 }


### PR DESCRIPTION
Last PR introduced a bug that removed the service account secret reference on reconcile. This caused kubernetes to recreate the SA token.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
