### PR TITLE
Reconcile Tenants and Clusters when their ServiceAccounts, Roles or Rolebindings change

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -25,6 +25,7 @@ type ClusterReconciler struct {
 //+kubebuilder:rbac:groups=syn.tools,resources=clusters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=syn.tools,resources=clusters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=syn.tools,resources=clusters/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	reqLogger := log.FromContext(ctx)

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/projectsyn/lieutenant-operator/controllers/gitrepo"
 	"github.com/projectsyn/lieutenant-operator/pipeline"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -27,6 +28,7 @@ type ClusterReconciler struct {
 //+kubebuilder:rbac:groups=syn.tools,resources=clusters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=syn.tools,resources=clusters/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;roles,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	reqLogger := log.FromContext(ctx)
@@ -70,5 +72,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&synv1alpha1.Cluster{}).
 		Owns(&synv1alpha1.GitRepo{}).
 		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -6,6 +6,7 @@ import (
 	"github.com/projectsyn/lieutenant-operator/controllers/cluster"
 	"github.com/projectsyn/lieutenant-operator/controllers/gitrepo"
 	"github.com/projectsyn/lieutenant-operator/pipeline"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -68,5 +69,6 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&synv1alpha1.Cluster{}).
 		Owns(&synv1alpha1.GitRepo{}).
+		Owns(&corev1.ServiceAccount{}).
 		Complete(r)
 }

--- a/controllers/tenant/role.go
+++ b/controllers/tenant/role.go
@@ -43,7 +43,7 @@ func newRole(scheme *runtime.Scheme, tenant *synv1alpha1.Tenant) (*rbacv1.Role, 
 		},
 	}
 	setManagedByLabel(role)
-	if err := controllerutil.SetOwnerReference(tenant, role, scheme); err != nil {
+	if err := controllerutil.SetControllerReference(tenant, role, scheme); err != nil {
 		return nil, err
 	}
 	roleUtil.EnsureRules(role)

--- a/controllers/tenant/role_binding.go
+++ b/controllers/tenant/role_binding.go
@@ -50,7 +50,7 @@ func NewRoleBinding(scheme *runtime.Scheme, tenant *synv1alpha1.Tenant) (*rbacv1
 	}
 
 	setManagedByLabel(&binding)
-	if err := controllerutil.SetOwnerReference(tenant, &binding, scheme); err != nil {
+	if err := controllerutil.SetControllerReference(tenant, &binding, scheme); err != nil {
 		return nil, err
 	}
 

--- a/controllers/tenant/service_account.go
+++ b/controllers/tenant/service_account.go
@@ -39,7 +39,7 @@ func newServiceAccount(scheme *runtime.Scheme, tenant *synv1alpha1.Tenant) (*cor
 		},
 	}
 	setManagedByLabel(sa)
-	if err := controllerutil.SetOwnerReference(tenant, sa, scheme); err != nil {
+	if err := controllerutil.SetControllerReference(tenant, sa, scheme); err != nil {
 		return nil, err
 	}
 

--- a/controllers/tenant_controller.go
+++ b/controllers/tenant_controller.go
@@ -6,6 +6,7 @@ import (
 	"github.com/projectsyn/lieutenant-operator/controllers/gitrepo"
 	"github.com/projectsyn/lieutenant-operator/controllers/tenant"
 	"github.com/projectsyn/lieutenant-operator/pipeline"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -70,5 +71,6 @@ func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&synv1alpha1.Tenant{}).
 		Owns(&synv1alpha1.GitRepo{}).
 		Owns(&synv1alpha1.Cluster{}).
+		Owns(&corev1.ServiceAccount{}).
 		Complete(r)
 }

--- a/controllers/tenant_controller.go
+++ b/controllers/tenant_controller.go
@@ -26,6 +26,7 @@ type TenantReconciler struct {
 //+kubebuilder:rbac:groups=syn.tools,resources=tenants/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=syn.tools,resources=tenants/finalizers,verbs=update
 //+kubebuilder:rbac:groups=syn.tools,resources=tenanttemplates,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.

--- a/controllers/tenant_controller.go
+++ b/controllers/tenant_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/projectsyn/lieutenant-operator/controllers/tenant"
 	"github.com/projectsyn/lieutenant-operator/pipeline"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -28,6 +29,7 @@ type TenantReconciler struct {
 //+kubebuilder:rbac:groups=syn.tools,resources=tenants/finalizers,verbs=update
 //+kubebuilder:rbac:groups=syn.tools,resources=tenanttemplates,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings;roles,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
@@ -72,5 +74,7 @@ func (r *TenantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&synv1alpha1.GitRepo{}).
 		Owns(&synv1alpha1.Cluster{}).
 		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }


### PR DESCRIPTION
We add ServiceAccounts, Roles and Rolebindings as owned resources when setting up the tenant and cluster controllers. This ensures that a reconcile of the owning tenant or cluster is triggered if its associated ServiceAccount is deleted.

Additionally, we change the owner reference on the tenant ServiceAccount, Role and RoleBinding to be a controller reference so that the reconcile for a tenant is actually triggered when its ServiceAccount is deleted. Notably, reconciles aren't triggered for owned resources, if the owner reference isn't a controller reference (cf. documentation for [controllerutil.SetControllerReference] and [controllerutil.SetOwnerReference])

[controllerutil.SetControllerReference]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil#SetControllerReference
[controllerutil.SetOwnerReference]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil#SetOwnerReference

Split out from #234 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
