### PR TITLE
Remove unnecessary `url.PathEscape` for `GetNamespace`

### DIFF
--- a/git/gitlab/gitlab.go
+++ b/git/gitlab/gitlab.go
@@ -253,7 +253,7 @@ func (g *Gitlab) New(options manager.RepoOptions) (manager.Repo, error) {
 
 func (g *Gitlab) getNamespaceID() (*int, error) {
 
-	fetchedNamespace, _, err := g.client.Namespaces.GetNamespace(url.PathEscape(g.ops.Path))
+	fetchedNamespace, _, err := g.client.Namespaces.GetNamespace(g.ops.Path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The new version of the GitLab library URL-escapes the provided repo path in `GetNamespace`, so we must not escape it ourselves anymore, as we otherwise get a double-URL-escaped value for the request, which then fails.

Also add a test case for creating a project in a subgroup.

Follow-up fix for #217 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
