### PR TITLE
Prevent URL getter from modifying struct

### DIFF
--- a/git/gitlab/gitlab.go
+++ b/git/gitlab/gitlab.go
@@ -220,13 +220,13 @@ func (g *Gitlab) Connect() error {
 // FullURL returns the complete url of this git repository
 func (g *Gitlab) FullURL() *url.URL {
 
-	sshURL := g.ops.URL
+	sshURL := *g.ops.URL
 
 	sshURL.Scheme = "ssh"
 	sshURL.User = url.User("git")
 	sshURL.Path = sshURL.Path + ".git"
 
-	return sshURL
+	return &sshURL
 }
 
 // TODO: this will be deprecated in favour of a fixed type definition in the

--- a/git/gitlab/gitlab_test.go
+++ b/git/gitlab/gitlab_test.go
@@ -582,3 +582,17 @@ func TestGitlab_CommitTemplateFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestGitlab_FullURL(t *testing.T) {
+	serverURL, err := url.Parse("git.example.com/foo/bar")
+	require.NoError(t, err)
+	expectedFullURL := "ssh://git@git.example.com/foo/bar.git"
+	g := &Gitlab{
+		ops: manager.RepoOptions{
+			URL: serverURL,
+		},
+	}
+	assert.Equal(t, expectedFullURL, g.FullURL().String())
+	assert.Equal(t, expectedFullURL, g.FullURL().String())
+	assert.Equal(t, expectedFullURL, g.FullURL().String())
+}


### PR DESCRIPTION
The getter accesses the URL pointer, modifying the url stored in the Gitlab struct.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
