### PR TITLE
Make git repo creation behaviour configurable

### DIFF
--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -34,6 +34,11 @@ type ClusterSpec struct {
 	// Archive: will archive the external resources, if it supports that
 	// +kubebuilder:validation:Enum=Delete;Retain;Archive
 	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
+	// CreationPolicy defines how the external resources should be treated upon CR creation.
+	// Create: will only create a new external resource and will not manage already existing resources
+	// Adopt:  will create a new external resource or will adopt and manage en already existing resource
+	// +kubebuilder:validation:Enum=Create;Adopt
+	CreationPolicy CreationPolicy `json:"creationPolicy,omitempty"`
 }
 
 // BootstrapToken this key is used only once for Steward to register.
@@ -97,6 +102,11 @@ func (c *Cluster) GetTenantRef() corev1.LocalObjectReference {
 // GetDeletionPolicy returns the object's deletion policy
 func (c *Cluster) GetDeletionPolicy() DeletionPolicy {
 	return c.Spec.DeletionPolicy
+}
+
+// GetCreationPolicy returns the object's deletion policy
+func (c *Cluster) GetCreationPolicy() CreationPolicy {
+	return c.Spec.CreationPolicy
 }
 
 // GetDisplayName returns the display name of the object

--- a/api/v1alpha1/cluster_types.go
+++ b/api/v1alpha1/cluster_types.go
@@ -36,7 +36,7 @@ type ClusterSpec struct {
 	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
 	// CreationPolicy defines how the external resources should be treated upon CR creation.
 	// Create: will only create a new external resource and will not manage already existing resources
-	// Adopt:  will create a new external resource or will adopt and manage en already existing resource
+	// Adopt:  will create a new external resource or will adopt and manage an already existing resource
 	// +kubebuilder:validation:Enum=Create;Adopt
 	CreationPolicy CreationPolicy `json:"creationPolicy,omitempty"`
 }
@@ -104,7 +104,7 @@ func (c *Cluster) GetDeletionPolicy() DeletionPolicy {
 	return c.Spec.DeletionPolicy
 }
 
-// GetCreationPolicy returns the object's deletion policy
+// GetCreationPolicy returns the object's creation policy
 func (c *Cluster) GetCreationPolicy() CreationPolicy {
 	return c.Spec.CreationPolicy
 }

--- a/api/v1alpha1/gitrepo_types.go
+++ b/api/v1alpha1/gitrepo_types.go
@@ -84,7 +84,7 @@ type GitRepoTemplate struct {
 	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
 	// CreationPolicy defines how the external resources should be treated upon CR creation.
 	// Create: will only create a new external resource and will not manage already existing resources
-	// Adopt:  will create a new external resource or will adopt and manage en already existing resource
+	// Adopt:  will create a new external resource or will adopt and manage an already existing resource
 	// +kubebuilder:validation:Enum=Create;Adopt
 	CreationPolicy CreationPolicy `json:"creationPolicy,omitempty"`
 }
@@ -157,7 +157,7 @@ func (g *GitRepo) GetDeletionPolicy() DeletionPolicy {
 	return g.Spec.DeletionPolicy
 }
 
-// GetCreationPolicy returns the object's deletion policy
+// GetCreationPolicy returns the object's creation policy
 func (g *GitRepo) GetCreationPolicy() CreationPolicy {
 	return g.Spec.CreationPolicy
 }

--- a/api/v1alpha1/gitrepo_types.go
+++ b/api/v1alpha1/gitrepo_types.go
@@ -31,6 +31,8 @@ const (
 	ArchivePolicy DeletionPolicy = "Archive"
 	DeletePolicy  DeletionPolicy = "Delete"
 	RetainPolicy  DeletionPolicy = "Retain"
+	CreatePolicy  CreationPolicy = "Create"
+	AdoptPolicy   CreationPolicy = "Adopt"
 )
 
 // GitPhase is the enum for the git phase status
@@ -44,6 +46,9 @@ type RepoType string
 
 // DeletionPolicy defines the type deletion policy
 type DeletionPolicy string
+
+// CreationPolicy defines the type creation policy
+type CreationPolicy string
 
 // GitRepoSpec defines the desired state of GitRepo
 type GitRepoSpec struct {
@@ -77,6 +82,11 @@ type GitRepoTemplate struct {
 	// Archive: will archive the external resources, if it supports that
 	// +kubebuilder:validation:Enum=Delete;Retain;Archive
 	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
+	// CreationPolicy defines how the external resources should be treated upon CR creation.
+	// Create: will only create a new external resource and will not manage already existing resources
+	// Adopt:  will create a new external resource or will adopt and manage en already existing resource
+	// +kubebuilder:validation:Enum=Create;Adopt
+	CreationPolicy CreationPolicy `json:"creationPolicy,omitempty"`
 }
 
 // DeployKey defines an SSH key to be used for git operations.
@@ -145,6 +155,11 @@ func (g *GitRepo) GetTenantRef() corev1.LocalObjectReference {
 // GetDeletionPolicy returns the object's deletion policy
 func (g *GitRepo) GetDeletionPolicy() DeletionPolicy {
 	return g.Spec.DeletionPolicy
+}
+
+// GetCreationPolicy returns the object's deletion policy
+func (g *GitRepo) GetCreationPolicy() CreationPolicy {
+	return g.Spec.CreationPolicy
 }
 
 // GetDisplayName returns the display name of the object

--- a/api/v1alpha1/tenant_types.go
+++ b/api/v1alpha1/tenant_types.go
@@ -30,7 +30,7 @@ type TenantSpec struct {
 	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
 	// CreationPolicy defines how the external resources should be treated upon CR creation.
 	// Create: will only create a new external resource and will not manage already existing resources
-	// Adopt:  will create a new external resource or will adopt and manage en already existing resource
+	// Adopt:  will create a new external resource or will adopt and manage an already existing resource
 	// +kubebuilder:validation:Enum=Create;Adopt
 	CreationPolicy CreationPolicy `json:"creationPolicy,omitempty"`
 	// ClusterTemplate defines a template which will be used to set defaults for the clusters of this tenant.
@@ -90,7 +90,7 @@ func (t *Tenant) GetDeletionPolicy() DeletionPolicy {
 	return t.Spec.DeletionPolicy
 }
 
-// GetCreationPolicy returns the object's deletion policy
+// GetCreationPolicy returns the object's creation policy
 func (t *Tenant) GetCreationPolicy() CreationPolicy {
 	return t.Spec.CreationPolicy
 }

--- a/api/v1alpha1/tenant_types.go
+++ b/api/v1alpha1/tenant_types.go
@@ -28,6 +28,11 @@ type TenantSpec struct {
 	// Archive: will archive the external resources, if it supports that
 	// +kubebuilder:validation:Enum=Delete;Retain;Archive
 	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty"`
+	// CreationPolicy defines how the external resources should be treated upon CR creation.
+	// Create: will only create a new external resource and will not manage already existing resources
+	// Adopt:  will create a new external resource or will adopt and manage en already existing resource
+	// +kubebuilder:validation:Enum=Create;Adopt
+	CreationPolicy CreationPolicy `json:"creationPolicy,omitempty"`
 	// ClusterTemplate defines a template which will be used to set defaults for the clusters of this tenant.
 	// The fields within this can use Go templating.
 	// See https://syn.tools/lieutenant-operator/explanations/templating.html for details.
@@ -83,6 +88,11 @@ func (t *Tenant) GetTenantRef() corev1.LocalObjectReference {
 // GetDeletionPolicy returns the object's deletion policy
 func (t *Tenant) GetDeletionPolicy() DeletionPolicy {
 	return t.Spec.DeletionPolicy
+}
+
+// GetCreationPolicy returns the object's deletion policy
+func (t *Tenant) GetCreationPolicy() CreationPolicy {
+	return t.Spec.CreationPolicy
 }
 
 // GetDisplayName returns the display name of the object

--- a/config/crd/bases/syn.tools_clusters.yaml
+++ b/config/crd/bases/syn.tools_clusters.yaml
@@ -50,7 +50,7 @@ spec:
                 description: 'CreationPolicy defines how the external resources should
                   be treated upon CR creation. Create: will only create a new external
                   resource and will not manage already existing resources Adopt:  will
-                  create a new external resource or will adopt and manage en already
+                  create a new external resource or will adopt and manage an already
                   existing resource'
                 enum:
                 - Create
@@ -99,7 +99,7 @@ spec:
                       should be treated upon CR creation. Create: will only create
                       a new external resource and will not manage already existing
                       resources Adopt:  will create a new external resource or will
-                      adopt and manage en already existing resource'
+                      adopt and manage an already existing resource'
                     enum:
                     - Create
                     - Adopt

--- a/config/crd/bases/syn.tools_clusters.yaml
+++ b/config/crd/bases/syn.tools_clusters.yaml
@@ -46,6 +46,16 @@ spec:
           spec:
             description: ClusterSpec defines the desired state of Cluster
             properties:
+              creationPolicy:
+                description: 'CreationPolicy defines how the external resources should
+                  be treated upon CR creation. Create: will only create a new external
+                  resource and will not manage already existing resources Adopt:  will
+                  create a new external resource or will adopt and manage en already
+                  existing resource'
+                enum:
+                - Create
+                - Adopt
+                type: string
               deletionPolicy:
                 description: 'DeletionPolicy defines how the external resources should
                   be treated upon CR deletion. Retain: will not delete any external
@@ -84,6 +94,16 @@ spec:
                           secret name must be unique.
                         type: string
                     type: object
+                  creationPolicy:
+                    description: 'CreationPolicy defines how the external resources
+                      should be treated upon CR creation. Create: will only create
+                      a new external resource and will not manage already existing
+                      resources Adopt:  will create a new external resource or will
+                      adopt and manage en already existing resource'
+                    enum:
+                    - Create
+                    - Adopt
+                    type: string
                   deletionPolicy:
                     description: 'DeletionPolicy defines how the external resources
                       should be treated upon CR deletion. Retain: will not delete

--- a/config/crd/bases/syn.tools_gitrepos.yaml
+++ b/config/crd/bases/syn.tools_gitrepos.yaml
@@ -62,6 +62,16 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+              creationPolicy:
+                description: 'CreationPolicy defines how the external resources should
+                  be treated upon CR creation. Create: will only create a new external
+                  resource and will not manage already existing resources Adopt:  will
+                  create a new external resource or will adopt and manage en already
+                  existing resource'
+                enum:
+                - Create
+                - Adopt
+                type: string
               deletionPolicy:
                 description: 'DeletionPolicy defines how the external resources should
                   be treated upon CR deletion. Retain: will not delete any external

--- a/config/crd/bases/syn.tools_gitrepos.yaml
+++ b/config/crd/bases/syn.tools_gitrepos.yaml
@@ -66,7 +66,7 @@ spec:
                 description: 'CreationPolicy defines how the external resources should
                   be treated upon CR creation. Create: will only create a new external
                   resource and will not manage already existing resources Adopt:  will
-                  create a new external resource or will adopt and manage en already
+                  create a new external resource or will adopt and manage an already
                   existing resource'
                 enum:
                 - Create

--- a/config/crd/bases/syn.tools_tenants.yaml
+++ b/config/crd/bases/syn.tools_tenants.yaml
@@ -49,6 +49,16 @@ spec:
                   this can use Go templating. See https://syn.tools/lieutenant-operator/explanations/templating.html
                   for details.
                 properties:
+                  creationPolicy:
+                    description: 'CreationPolicy defines how the external resources
+                      should be treated upon CR creation. Create: will only create
+                      a new external resource and will not manage already existing
+                      resources Adopt:  will create a new external resource or will
+                      adopt and manage en already existing resource'
+                    enum:
+                    - Create
+                    - Adopt
+                    type: string
                   deletionPolicy:
                     description: 'DeletionPolicy defines how the external resources
                       should be treated upon CR deletion. Retain: will not delete
@@ -90,6 +100,16 @@ spec:
                               the secret name must be unique.
                             type: string
                         type: object
+                      creationPolicy:
+                        description: 'CreationPolicy defines how the external resources
+                          should be treated upon CR creation. Create: will only create
+                          a new external resource and will not manage already existing
+                          resources Adopt:  will create a new external resource or
+                          will adopt and manage en already existing resource'
+                        enum:
+                        - Create
+                        - Adopt
+                        type: string
                       deletionPolicy:
                         description: 'DeletionPolicy defines how the external resources
                           should be treated upon CR deletion. Retain: will not delete
@@ -174,6 +194,16 @@ spec:
                     description: TokenLifetime set the token lifetime
                     type: string
                 type: object
+              creationPolicy:
+                description: 'CreationPolicy defines how the external resources should
+                  be treated upon CR creation. Create: will only create a new external
+                  resource and will not manage already existing resources Adopt:  will
+                  create a new external resource or will adopt and manage en already
+                  existing resource'
+                enum:
+                - Create
+                - Adopt
+                type: string
               deletionPolicy:
                 description: 'DeletionPolicy defines how the external resources should
                   be treated upon CR deletion. Retain: will not delete any external
@@ -209,6 +239,16 @@ spec:
                           secret name must be unique.
                         type: string
                     type: object
+                  creationPolicy:
+                    description: 'CreationPolicy defines how the external resources
+                      should be treated upon CR creation. Create: will only create
+                      a new external resource and will not manage already existing
+                      resources Adopt:  will create a new external resource or will
+                      adopt and manage en already existing resource'
+                    enum:
+                    - Create
+                    - Adopt
+                    type: string
                   deletionPolicy:
                     description: 'DeletionPolicy defines how the external resources
                       should be treated upon CR deletion. Retain: will not delete

--- a/config/crd/bases/syn.tools_tenants.yaml
+++ b/config/crd/bases/syn.tools_tenants.yaml
@@ -54,7 +54,7 @@ spec:
                       should be treated upon CR creation. Create: will only create
                       a new external resource and will not manage already existing
                       resources Adopt:  will create a new external resource or will
-                      adopt and manage en already existing resource'
+                      adopt and manage an already existing resource'
                     enum:
                     - Create
                     - Adopt
@@ -105,7 +105,7 @@ spec:
                           should be treated upon CR creation. Create: will only create
                           a new external resource and will not manage already existing
                           resources Adopt:  will create a new external resource or
-                          will adopt and manage en already existing resource'
+                          will adopt and manage an already existing resource'
                         enum:
                         - Create
                         - Adopt
@@ -198,7 +198,7 @@ spec:
                 description: 'CreationPolicy defines how the external resources should
                   be treated upon CR creation. Create: will only create a new external
                   resource and will not manage already existing resources Adopt:  will
-                  create a new external resource or will adopt and manage en already
+                  create a new external resource or will adopt and manage an already
                   existing resource'
                 enum:
                 - Create
@@ -244,7 +244,7 @@ spec:
                       should be treated upon CR creation. Create: will only create
                       a new external resource and will not manage already existing
                       resources Adopt:  will create a new external resource or will
-                      adopt and manage en already existing resource'
+                      adopt and manage an already existing resource'
                     enum:
                     - Create
                     - Adopt

--- a/config/crd/bases/syn.tools_tenanttemplates.yaml
+++ b/config/crd/bases/syn.tools_tenanttemplates.yaml
@@ -49,6 +49,16 @@ spec:
                   this can use Go templating. See https://syn.tools/lieutenant-operator/explanations/templating.html
                   for details.
                 properties:
+                  creationPolicy:
+                    description: 'CreationPolicy defines how the external resources
+                      should be treated upon CR creation. Create: will only create
+                      a new external resource and will not manage already existing
+                      resources Adopt:  will create a new external resource or will
+                      adopt and manage en already existing resource'
+                    enum:
+                    - Create
+                    - Adopt
+                    type: string
                   deletionPolicy:
                     description: 'DeletionPolicy defines how the external resources
                       should be treated upon CR deletion. Retain: will not delete
@@ -90,6 +100,16 @@ spec:
                               the secret name must be unique.
                             type: string
                         type: object
+                      creationPolicy:
+                        description: 'CreationPolicy defines how the external resources
+                          should be treated upon CR creation. Create: will only create
+                          a new external resource and will not manage already existing
+                          resources Adopt:  will create a new external resource or
+                          will adopt and manage en already existing resource'
+                        enum:
+                        - Create
+                        - Adopt
+                        type: string
                       deletionPolicy:
                         description: 'DeletionPolicy defines how the external resources
                           should be treated upon CR deletion. Retain: will not delete
@@ -174,6 +194,16 @@ spec:
                     description: TokenLifetime set the token lifetime
                     type: string
                 type: object
+              creationPolicy:
+                description: 'CreationPolicy defines how the external resources should
+                  be treated upon CR creation. Create: will only create a new external
+                  resource and will not manage already existing resources Adopt:  will
+                  create a new external resource or will adopt and manage en already
+                  existing resource'
+                enum:
+                - Create
+                - Adopt
+                type: string
               deletionPolicy:
                 description: 'DeletionPolicy defines how the external resources should
                   be treated upon CR deletion. Retain: will not delete any external
@@ -209,6 +239,16 @@ spec:
                           secret name must be unique.
                         type: string
                     type: object
+                  creationPolicy:
+                    description: 'CreationPolicy defines how the external resources
+                      should be treated upon CR creation. Create: will only create
+                      a new external resource and will not manage already existing
+                      resources Adopt:  will create a new external resource or will
+                      adopt and manage en already existing resource'
+                    enum:
+                    - Create
+                    - Adopt
+                    type: string
                   deletionPolicy:
                     description: 'DeletionPolicy defines how the external resources
                       should be treated upon CR deletion. Retain: will not delete

--- a/config/crd/bases/syn.tools_tenanttemplates.yaml
+++ b/config/crd/bases/syn.tools_tenanttemplates.yaml
@@ -54,7 +54,7 @@ spec:
                       should be treated upon CR creation. Create: will only create
                       a new external resource and will not manage already existing
                       resources Adopt:  will create a new external resource or will
-                      adopt and manage en already existing resource'
+                      adopt and manage an already existing resource'
                     enum:
                     - Create
                     - Adopt
@@ -105,7 +105,7 @@ spec:
                           should be treated upon CR creation. Create: will only create
                           a new external resource and will not manage already existing
                           resources Adopt:  will create a new external resource or
-                          will adopt and manage en already existing resource'
+                          will adopt and manage an already existing resource'
                         enum:
                         - Create
                         - Adopt
@@ -198,7 +198,7 @@ spec:
                 description: 'CreationPolicy defines how the external resources should
                   be treated upon CR creation. Create: will only create a new external
                   resource and will not manage already existing resources Adopt:  will
-                  create a new external resource or will adopt and manage en already
+                  create a new external resource or will adopt and manage an already
                   existing resource'
                 enum:
                 - Create
@@ -244,7 +244,7 @@ spec:
                       should be treated upon CR creation. Create: will only create
                       a new external resource and will not manage already existing
                       resources Adopt:  will create a new external resource or will
-                      adopt and manage en already existing resource'
+                      adopt and manage an already existing resource'
                     enum:
                     - Create
                     - Adopt

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -23,7 +23,8 @@ type ClusterReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	CreateSATokenSecret bool
+	CreateSATokenSecret   bool
+	DefaultCreationPolicy synv1alpha1.CreationPolicy
 }
 
 //+kubebuilder:rbac:groups=syn.tools,resources=clusters,verbs=get;list;watch;create;update;patch;delete
@@ -47,12 +48,13 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 	}
 
 	data := &pipeline.Context{
-		Context:             ctx,
-		Client:              r.Client,
-		Log:                 reqLogger,
-		FinalizerName:       synv1alpha1.FinalizerName,
-		Reconciler:          r,
-		CreateSATokenSecret: r.CreateSATokenSecret,
+		Context:               ctx,
+		Client:                r.Client,
+		Log:                   reqLogger,
+		FinalizerName:         synv1alpha1.FinalizerName,
+		Reconciler:            r,
+		CreateSATokenSecret:   r.CreateSATokenSecret,
+		DefaultCreationPolicy: r.DefaultCreationPolicy,
 	}
 
 	steps := []pipeline.Step{

--- a/controllers/gitrepo/steps.go
+++ b/controllers/gitrepo/steps.go
@@ -60,7 +60,7 @@ func steps(obj pipeline.Object, data *pipeline.Context, getGitClient gitClientFa
 		data.Log.Info("successfully created the repository")
 	}
 
-	if instance.Status.URL != repo.FullURL().String() {
+	if instance.Status.URL != repo.FullURL().String() && instance.Spec.CreationPolicy != synv1alpha1.AdoptPolicy {
 		var err error
 		if !data.Deleted {
 			phase := synv1alpha1.Failed

--- a/controllers/gitrepo/utils.go
+++ b/controllers/gitrepo/utils.go
@@ -39,6 +39,13 @@ func CreateOrUpdate(obj pipeline.Object, data *pipeline.Context) pipeline.Result
 			template.DeletionPolicy = obj.GetDeletionPolicy()
 		}
 	}
+	if template.CreationPolicy == "" {
+		if obj.GetCreationPolicy() == "" {
+			template.CreationPolicy = data.DefaultCreationPolicy
+		} else {
+			template.CreationPolicy = obj.GetCreationPolicy()
+		}
+	}
 
 	if template.RepoType == synv1alpha1.DefaultRepoType {
 		template.RepoType = synv1alpha1.AutoRepoType

--- a/controllers/gitrepo_controller.go
+++ b/controllers/gitrepo_controller.go
@@ -19,6 +19,8 @@ import (
 type GitRepoReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	DefaultCreationPolicy synv1alpha1.CreationPolicy
 }
 
 //+kubebuilder:rbac:groups=syn.tools,resources=gitrepos,verbs=get;list;watch;create;update;patch;delete
@@ -46,11 +48,12 @@ func (r *GitRepoReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 	}
 
 	data := &pipeline.Context{
-		Context:       ctx,
-		Client:        r.Client,
-		Log:           reqLogger,
-		FinalizerName: synv1alpha1.FinalizerName,
-		Reconciler:    r,
+		Context:               ctx,
+		Client:                r.Client,
+		Log:                   reqLogger,
+		FinalizerName:         synv1alpha1.FinalizerName,
+		Reconciler:            r,
+		DefaultCreationPolicy: r.DefaultCreationPolicy,
 	}
 
 	steps := []pipeline.Step{

--- a/controllers/tenant_controller.go
+++ b/controllers/tenant_controller.go
@@ -23,7 +23,8 @@ type TenantReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	CreateSATokenSecret bool
+	CreateSATokenSecret   bool
+	DefaultCreationPolicy synv1alpha1.CreationPolicy
 }
 
 //+kubebuilder:rbac:groups=syn.tools,resources=tenants,verbs=get;list;watch;create;update;patch;delete
@@ -50,12 +51,13 @@ func (r *TenantReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	}
 
 	data := &pipeline.Context{
-		Context:             ctx,
-		Client:              r.Client,
-		Log:                 reqLogger,
-		FinalizerName:       "",
-		Reconciler:          r,
-		CreateSATokenSecret: r.CreateSATokenSecret,
+		Context:               ctx,
+		Client:                r.Client,
+		Log:                   reqLogger,
+		FinalizerName:         "",
+		Reconciler:            r,
+		CreateSATokenSecret:   r.CreateSATokenSecret,
+		DefaultCreationPolicy: r.DefaultCreationPolicy,
 	}
 
 	steps := []pipeline.Step{

--- a/docs/modules/ROOT/pages/explanations/adoption.adoc
+++ b/docs/modules/ROOT/pages/explanations/adoption.adoc
@@ -1,0 +1,9 @@
+= Repository Adoption
+
+Repository Adoption is the process of managing Git repositories that weren't created by Lieutenant.
+
+By default if you create a `GitRepo` resource that references a Git repository that already exits, Lieutenant will not adopt and manage it.
+This should prevent accidental modification of exiting repositories and also avoids issues if two `GitRepo` resources reference the same repository.
+
+Adoption can be enabled per `GitRepo` by setting `spec.creationPolicy` to `Adopt` or as a global default by setting `DEFAULT_CREATION_POLICY` to `Adopt`.
+Enabling adoption can be helpful for migrations or disaster recovery.

--- a/docs/modules/ROOT/pages/explanations/adoption.adoc
+++ b/docs/modules/ROOT/pages/explanations/adoption.adoc
@@ -3,7 +3,7 @@
 Repository Adoption is the process of managing Git repositories that weren't created by Lieutenant.
 
 By default if you create a `GitRepo` resource that references a Git repository that already exits, Lieutenant will not adopt and manage it.
-This should prevent accidental modification of exiting repositories and also avoids issues if two `GitRepo` resources reference the same repository.
+This should prevent accidental modification of existing repositories and also avoids issues if two `GitRepo` resources reference the same repository.
 
 Adoption can be enabled per `GitRepo` by setting `spec.creationPolicy` to `Adopt` or as a global default by setting `DEFAULT_CREATION_POLICY` to `Adopt`.
 Enabling adoption can be helpful for migrations or disaster recovery.

--- a/docs/modules/ROOT/pages/references/api-reference.adoc
+++ b/docs/modules/ROOT/pages/references/api-reference.adoc
@@ -86,7 +86,7 @@ ClusterSpec defines the desired state of Cluster
 | *`tokenLifeTime`* __string__ | TokenLifetime set the token lifetime
 | *`facts`* __object (keys:string, values:string)__ | Facts are key/value pairs for statically configured facts
 | *`deletionPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-deletionpolicy[$$DeletionPolicy$$]__ | DeletionPolicy defines how the external resources should be treated upon CR deletion. Retain: will not delete any external resources Delete: will delete the external resources Archive: will archive the external resources, if it supports that
-| *`creationPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-creationpolicy[$$CreationPolicy$$]__ | CreationPolicy defines how the external resources should be treated upon CR creation. Create: will only create a new external resource and will not manage already existing resources Adopt:  will create a new external resource or will adopt and manage en already existing resource
+| *`creationPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-creationpolicy[$$CreationPolicy$$]__ | CreationPolicy defines how the external resources should be treated upon CR creation. Create: will only create a new external resource and will not manage already existing resources Adopt:  will create a new external resource or will adopt and manage an already existing resource
 |===
 
 
@@ -205,7 +205,7 @@ GitRepoTemplate is used for templating git repos, it does not contain the tenant
 | *`displayName`* __string__ | DisplayName of Git repository
 | *`templateFiles`* __object (keys:string, values:string)__ | TemplateFiles is a list of files that should be pushed to the repository after its creation.
 | *`deletionPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-deletionpolicy[$$DeletionPolicy$$]__ | DeletionPolicy defines how the external resources should be treated upon CR deletion. Retain: will not delete any external resources Delete: will delete the external resources Archive: will archive the external resources, if it supports that
-| *`creationPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-creationpolicy[$$CreationPolicy$$]__ | CreationPolicy defines how the external resources should be treated upon CR creation. Create: will only create a new external resource and will not manage already existing resources Adopt:  will create a new external resource or will adopt and manage en already existing resource
+| *`creationPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-creationpolicy[$$CreationPolicy$$]__ | CreationPolicy defines how the external resources should be treated upon CR creation. Create: will only create a new external resource and will not manage already existing resources Adopt:  will create a new external resource or will adopt and manage an already existing resource
 |===
 
 
@@ -263,7 +263,7 @@ TenantSpec defines the desired state of Tenant
 | *`globalGitRepoRevision`* __string__ | GlobalGitRepoRevision allows to configure the revision of the global configuration to use. It can be any git tree-ish reference. Defaults to HEAD if left empty.
 | *`gitRepoTemplate`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-gitrepotemplate[$$GitRepoTemplate$$]__ | GitRepoTemplate Template for managing the GitRepo object. If not set, no GitRepo object will be created.
 | *`deletionPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-deletionpolicy[$$DeletionPolicy$$]__ | DeletionPolicy defines how the external resources should be treated upon CR deletion. Retain: will not delete any external resources Delete: will delete the external resources Archive: will archive the external resources, if it supports that
-| *`creationPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-creationpolicy[$$CreationPolicy$$]__ | CreationPolicy defines how the external resources should be treated upon CR creation. Create: will only create a new external resource and will not manage already existing resources Adopt:  will create a new external resource or will adopt and manage en already existing resource
+| *`creationPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-creationpolicy[$$CreationPolicy$$]__ | CreationPolicy defines how the external resources should be treated upon CR creation. Create: will only create a new external resource and will not manage already existing resources Adopt:  will create a new external resource or will adopt and manage an already existing resource
 | *`clusterTemplate`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-clusterspec[$$ClusterSpec$$]__ | ClusterTemplate defines a template which will be used to set defaults for the clusters of this tenant. The fields within this can use Go templating. See https://syn.tools/lieutenant-operator/explanations/templating.html for details.
 |===
 

--- a/docs/modules/ROOT/pages/references/api-reference.adoc
+++ b/docs/modules/ROOT/pages/references/api-reference.adoc
@@ -86,8 +86,23 @@ ClusterSpec defines the desired state of Cluster
 | *`tokenLifeTime`* __string__ | TokenLifetime set the token lifetime
 | *`facts`* __object (keys:string, values:string)__ | Facts are key/value pairs for statically configured facts
 | *`deletionPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-deletionpolicy[$$DeletionPolicy$$]__ | DeletionPolicy defines how the external resources should be treated upon CR deletion. Retain: will not delete any external resources Delete: will delete the external resources Archive: will archive the external resources, if it supports that
+| *`creationPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-creationpolicy[$$CreationPolicy$$]__ | CreationPolicy defines how the external resources should be treated upon CR creation. Create: will only create a new external resource and will not manage already existing resources Adopt:  will create a new external resource or will adopt and manage en already existing resource
 |===
 
+
+
+
+[id="{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-creationpolicy"]
+=== CreationPolicy (string) 
+
+CreationPolicy defines the type creation policy
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-clusterspec[$$ClusterSpec$$]
+- xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-gitrepotemplate[$$GitRepoTemplate$$]
+- xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-tenantspec[$$TenantSpec$$]
+****
 
 
 
@@ -190,6 +205,7 @@ GitRepoTemplate is used for templating git repos, it does not contain the tenant
 | *`displayName`* __string__ | DisplayName of Git repository
 | *`templateFiles`* __object (keys:string, values:string)__ | TemplateFiles is a list of files that should be pushed to the repository after its creation.
 | *`deletionPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-deletionpolicy[$$DeletionPolicy$$]__ | DeletionPolicy defines how the external resources should be treated upon CR deletion. Retain: will not delete any external resources Delete: will delete the external resources Archive: will archive the external resources, if it supports that
+| *`creationPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-creationpolicy[$$CreationPolicy$$]__ | CreationPolicy defines how the external resources should be treated upon CR creation. Create: will only create a new external resource and will not manage already existing resources Adopt:  will create a new external resource or will adopt and manage en already existing resource
 |===
 
 
@@ -247,6 +263,7 @@ TenantSpec defines the desired state of Tenant
 | *`globalGitRepoRevision`* __string__ | GlobalGitRepoRevision allows to configure the revision of the global configuration to use. It can be any git tree-ish reference. Defaults to HEAD if left empty.
 | *`gitRepoTemplate`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-gitrepotemplate[$$GitRepoTemplate$$]__ | GitRepoTemplate Template for managing the GitRepo object. If not set, no GitRepo object will be created.
 | *`deletionPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-deletionpolicy[$$DeletionPolicy$$]__ | DeletionPolicy defines how the external resources should be treated upon CR deletion. Retain: will not delete any external resources Delete: will delete the external resources Archive: will archive the external resources, if it supports that
+| *`creationPolicy`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-creationpolicy[$$CreationPolicy$$]__ | CreationPolicy defines how the external resources should be treated upon CR creation. Create: will only create a new external resource and will not manage already existing resources Adopt:  will create a new external resource or will adopt and manage en already existing resource
 | *`clusterTemplate`* __xref:{anchor_prefix}-github-com-projectsyn-lieutenant-operator-api-v1alpha1-clusterspec[$$ClusterSpec$$]__ | ClusterTemplate defines a template which will be used to set defaults for the clusters of this tenant. The fields within this can use Go templating. See https://syn.tools/lieutenant-operator/explanations/templating.html for details.
 |===
 

--- a/docs/modules/ROOT/pages/references/configuration.adoc
+++ b/docs/modules/ROOT/pages/references/configuration.adoc
@@ -33,6 +33,11 @@ Lieutenant Operator is configured via environment variables:
 |Sets what deletion policy for external resources (Git, Vault) should be used by default. One of `Archive`, `Delete`, `Retain`. See xref:lieutenant-operator:ROOT:explanations/deletion.adoc[Explanation/Object Deletion] for more information.
 |Archive
 
+|DEFAULT_CREATION_POLICY
+|Sets what creation policy for Git repositories should be used by default. One of `Create` or `Adopt`. See xref:lieutenant-operator:ROOT:explanations/adption.adoc[Object Adoption] for more information.
+|Create
+
+
 |LIEUTENANT_DELETE_PROTECTION
 |Defines whether the annotation to protect for accidental deletion should be set by default. See xref:lieutenant-operator:ROOT:explanations/deletion.adoc[Explanation/Object Deletion] for more information.
 |true

--- a/main.go
+++ b/main.go
@@ -32,10 +32,10 @@ const (
 	// which specifies the Namespace to watch.
 	// An empty value means the operator is running with cluster scope.
 	watchNamespaceEnvVar = "WATCH_NAMESPACE"
-	// createSAEnvVar is the contant for the env variable which indicates
+	// createSAEnvVar is the constant for the env variable which indicates
 	// whether to create ServiceAccount token secrets
 	createSATokenEnvVar = "LIEUTENANT_CREATE_SERVICEACCOUNT_TOKEN_SECRET"
-	// createSAEnvVar is the contant for the env variable which indicates
+	// createSAEnvVar is the constant for the env variable which indicates
 	// the default creation policy for git repositories
 	defaultCreationPolicy = "DEFAULT_CREATION_POLICY"
 )

--- a/main.go
+++ b/main.go
@@ -32,9 +32,12 @@ const (
 	// which specifies the Namespace to watch.
 	// An empty value means the operator is running with cluster scope.
 	watchNamespaceEnvVar = "WATCH_NAMESPACE"
-	// createSAEnvVar is the contant nfor the env variable which indicates
+	// createSAEnvVar is the contant for the env variable which indicates
 	// whether to create ServiceAccount token secrets
 	createSATokenEnvVar = "LIEUTENANT_CREATE_SERVICEACCOUNT_TOKEN_SECRET"
+	// createSAEnvVar is the contant for the env variable which indicates
+	// the default creation policy for git repositories
+	defaultCreationPolicy = "DEFAULT_CREATION_POLICY"
 )
 
 func init() {
@@ -73,6 +76,8 @@ func main() {
 			"the operator won't manage ServiceAccount token secrets.")
 	}
 
+	creationPolicy := getDefaultCreationPolicy()
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
@@ -88,24 +93,27 @@ func main() {
 	}
 
 	if err = (&controllers.ClusterReconciler{
-		Client:              mgr.GetClient(),
-		Scheme:              mgr.GetScheme(),
-		CreateSATokenSecret: createSATokenSecret,
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		CreateSATokenSecret:   createSATokenSecret,
+		DefaultCreationPolicy: creationPolicy,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cluster")
 		os.Exit(1)
 	}
 	if err = (&controllers.GitRepoReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		DefaultCreationPolicy: creationPolicy,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GitRepo")
 		os.Exit(1)
 	}
 	if err = (&controllers.TenantReconciler{
-		Client:              mgr.GetClient(),
-		Scheme:              mgr.GetScheme(),
-		CreateSATokenSecret: createSATokenSecret,
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		CreateSATokenSecret:   createSATokenSecret,
+		DefaultCreationPolicy: creationPolicy,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Tenant")
 		os.Exit(1)
@@ -149,4 +157,19 @@ func getCreateSATokenSecret() (bool, error) {
 		return false, fmt.Errorf("unable to parse '%s': %v", value, err)
 	}
 	return create, nil
+}
+
+// getDefaultCreationPolicy returns to fallback creation policy for git repositories
+func getDefaultCreationPolicy() synv1alpha1.CreationPolicy {
+	p, found := os.LookupEnv(defaultCreationPolicy)
+	if !found {
+		return synv1alpha1.CreatePolicy
+	}
+	cp := synv1alpha1.CreationPolicy(p)
+	switch cp {
+	case synv1alpha1.CreatePolicy, synv1alpha1.AdoptPolicy:
+		return cp
+	default:
+		return synv1alpha1.CreatePolicy
+	}
 }

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -26,6 +26,7 @@ type Object interface {
 	GroupVersionKind() schema.GroupVersionKind
 	GetTenantRef() corev1.LocalObjectReference
 	GetDeletionPolicy() synv1alpha1.DeletionPolicy
+	GetCreationPolicy() synv1alpha1.CreationPolicy
 	GetDisplayName() string
 	SetGitRepoURLAndHostKeys(URL, hostKeys string)
 	GetMeta() metav1.ObjectMeta
@@ -35,14 +36,15 @@ type Object interface {
 
 // Context contains additional data about the CRD being processed.
 type Context struct {
-	Context             context.Context
-	FinalizerName       string
-	Client              client.Client
-	Log                 logr.Logger
-	Deleted             bool
-	originalObject      Object
-	Reconciler          reconcile.Reconciler
-	CreateSATokenSecret bool
+	Context               context.Context
+	FinalizerName         string
+	Client                client.Client
+	Log                   logr.Logger
+	Deleted               bool
+	originalObject        Object
+	Reconciler            reconcile.Reconciler
+	CreateSATokenSecret   bool
+	DefaultCreationPolicy synv1alpha1.CreationPolicy
 }
 
 // Result indicates whether the current execution should be aborted and


### PR DESCRIPTION
This commit introduces a new field `CreationPolicy` for all managed resoruces. This field configures how Lieutenant handles the creation of Git repositories.

By default Lieutenant will not manage git repositories it did not create itself. This behaviour can be changed by setting the Creation Policy to `adopt`, which will allows Lieutenant to manage existing repositories. This can be helpful for migrations or recovery.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
