### PR TITLE
Explicitly set `preserveUnknownFields` to `false`

### DIFF
--- a/config/crd/bases/syn.tools_clusters.yaml
+++ b/config/crd/bases/syn.tools_clusters.yaml
@@ -12,6 +12,7 @@ spec:
     listKind: ClusterList
     plural: clusters
     singular: cluster
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/config/crd/bases/syn.tools_gitrepos.yaml
+++ b/config/crd/bases/syn.tools_gitrepos.yaml
@@ -12,6 +12,7 @@ spec:
     listKind: GitRepoList
     plural: gitrepos
     singular: gitrepo
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/config/crd/bases/syn.tools_tenants.yaml
+++ b/config/crd/bases/syn.tools_tenants.yaml
@@ -12,6 +12,7 @@ spec:
     listKind: TenantList
     plural: tenants
     singular: tenant
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/config/crd/bases/syn.tools_tenanttemplates.yaml
+++ b/config/crd/bases/syn.tools_tenanttemplates.yaml
@@ -12,6 +12,7 @@ spec:
     listKind: TenantTemplateList
     plural: tenanttemplates
     singular: tenanttemplate
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/generate.go
+++ b/generate.go
@@ -4,7 +4,7 @@
 package main
 
 //go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
-//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=${CRD_ROOT_DIR}/bases crd:crdVersions=v1
+//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=${CRD_ROOT_DIR}/bases crd:crdVersions=v1,deprecatedV1beta1CompatibilityPreserveUnknownFields=false
 
 // Generate API reference documentation
 //go:generate go run github.com/elastic/crd-ref-docs --source-path=api/v1alpha1 --config=docs/api-gen-config.yaml --renderer=asciidoctor --templates-dir=docs/api-templates --output-path=${CRD_DOCS_REF_PATH}


### PR DESCRIPTION
This is a leftover from pre-`v1` lieutenant. CRDs had the API version `v1beta1` which, when converted to `v1`, set `preserveUnknownFields=true`. Since the field was never explicitly managed it stayed `true` on clusters that had lieutenant `< v1` installed and was false on clusters that never used a `< v1` lieutenant.

The introduction of kubebuilder defaults with the upgrade of `k8s.io/api/core broke` old installations since defaults are not compatible with `preserveUnknownFields=true`.

This commit explicitly sets `preserveUnknownFields` to `false` in all CRDs.

Commit changing API version: https://github.com/projectsyn/lieutenant-operator/commit/8839a084ee005d084fe3f9ab7b814845f93bcc7d

Dependency upgrade: https://github.com/projectsyn/lieutenant-operator/commit/2d59a4c5882822ec7fd53bbfa57e201b8e0b1d5f#diff-3399214b42d027ec91b2533bc7401c1b69aa8bbf96f2870840cc03ca2d0ebebdR184

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
