### PR TITLE
Allow clusters to `update` and `patch` cluster status

### DIFF
--- a/controllers/cluster/rbac.go
+++ b/controllers/cluster/rbac.go
@@ -58,7 +58,7 @@ func createOrUpdateClusterRole(ctx context.Context, c client.Client, objMeta met
 		Rules: []rbacv1.PolicyRule{{
 			APIGroups:     []string{synv1alpha1.GroupVersion.Group},
 			Resources:     []string{"clusters", "clusters/status"},
-			Verbs:         []string{"get", "update"},
+			Verbs:         []string{"get", "update", "patch"},
 			ResourceNames: []string{objMeta.Name},
 		}},
 	}


### PR DESCRIPTION
Fixes Commodore CI compilation which uses `patch` for `compileMeta`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
