### PR TITLE
Fix tenant without clusters allowed access to all clusters

### DIFF
--- a/controllers/tenant/role.go
+++ b/controllers/tenant/role.go
@@ -44,18 +44,21 @@ func reconcileRole(obj pipeline.Object, data *pipeline.Context) pipeline.Result 
 				Resources:     []string{"tenants"},
 				ResourceNames: []string{tenant.Name},
 			},
-			{
-				APIGroups:     []string{synv1alpha1.GroupVersion.Group},
-				Verbs:         []string{"get"},
-				Resources:     []string{"clusters"},
-				ResourceNames: clusterNames,
-			},
-			{
-				APIGroups:     []string{synv1alpha1.GroupVersion.Group},
-				Verbs:         []string{"get", "update", "patch"},
-				Resources:     []string{"clusters/status"},
-				ResourceNames: clusterNames,
-			},
+		}
+		if len(clusterNames) > 0 {
+			role.Rules = append(role.Rules,
+				rbacv1.PolicyRule{
+					APIGroups:     []string{synv1alpha1.GroupVersion.Group},
+					Verbs:         []string{"get"},
+					Resources:     []string{"clusters"},
+					ResourceNames: clusterNames,
+				},
+				rbacv1.PolicyRule{
+					APIGroups:     []string{synv1alpha1.GroupVersion.Group},
+					Verbs:         []string{"get", "update", "patch"},
+					Resources:     []string{"clusters/status"},
+					ResourceNames: clusterNames,
+				})
 		}
 		return controllerutil.SetControllerReference(tenant, &role, data.Client.Scheme())
 	})


### PR DESCRIPTION
Follow up of the cleanup in #272 .

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
