### PR TITLE
Fix initialization of GitLab repos

### DIFF
--- a/git/gitlab/gitlab.go
+++ b/git/gitlab/gitlab.go
@@ -401,7 +401,8 @@ func (g *Gitlab) compareFiles() ([]manager.CommitFile, error) {
 		if err != nil {
 			// if the tree is not found it's probably just because there are no files at all currently...
 			// So we have to apply all pending ones.
-			if strings.Contains(err.Error(), "Tree Not Found") {
+			if errors.Is(err, gitlab.ErrNotFound) {
+				g.log.Info("ListTree got 404; most likely no files found in repository, applying all pending files")
 
 				for name, content := range g.ops.TemplateFiles {
 					if content != manager.DeletionMagicString {

--- a/git/gitlab/gitlab_test.go
+++ b/git/gitlab/gitlab_test.go
@@ -435,7 +435,7 @@ func testGetCommitServer(t *testing.T, files []string) *httptest.Server {
 
 	mux.HandleFunc("/api/v4/projects/3/repository/tree", func(res http.ResponseWriter, req *http.Request) {
 		if len(files) == 0 {
-			_, _ = res.Write([]byte(`[]`))
+			res.WriteHeader(http.StatusNotFound)
 			return
 		}
 


### PR DESCRIPTION
GitLab returns `404` on a `repository/tree` call if the repo has zero commits. We checked against the error message but the client library started to return a static `404` error which makes our check fail.

This commit changes the checking logic to check for the clients static `ErrNotFound` error. This might catch other errors too (repo does not exists at all), but those errors will be caught in the next step.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
