### PR TITLE
Force refresh valid but not saved token

### DIFF
--- a/controllers/gitrepo/steps.go
+++ b/controllers/gitrepo/steps.go
@@ -156,7 +156,7 @@ func ensureAccessToken(ctx context.Context, cli client.Client, instance *synv1al
 		uid := secret.Annotations[LieutenantAccessTokenUIDAnnotation]
 
 		pat, err := repo.EnsureProjectAccessToken(ctx, instance.GetName(), manager.EnsureProjectAccessTokenOptions{
-			UID: uid,
+			UID: &uid,
 		})
 		if err != nil {
 			return fmt.Errorf("error ensuring project access token: %w", err)

--- a/git/gitlab/gitlab.go
+++ b/git/gitlab/gitlab.go
@@ -497,7 +497,7 @@ func (g *Gitlab) EnsureProjectAccessToken(ctx context.Context, name string, opts
 		return 0
 	})
 
-	if opts.UID == "" {
+	if opts.UID == nil {
 		if len(validATs) > 0 {
 			return manager.ProjectAccessToken{
 				UID:       strconv.Itoa(validATs[0].ID),
@@ -505,10 +505,11 @@ func (g *Gitlab) EnsureProjectAccessToken(ctx context.Context, name string, opts
 			}, nil
 		}
 	} else {
+		uid := *opts.UID
 		for _, token := range validATs {
-			if strconv.Itoa(token.ID) == opts.UID {
+			if strconv.Itoa(token.ID) == uid {
 				return manager.ProjectAccessToken{
-					UID:       opts.UID,
+					UID:       uid,
 					ExpiresAt: time.Time(*token.ExpiresAt),
 				}, nil
 			}

--- a/git/manager/manager.go
+++ b/git/manager/manager.go
@@ -144,7 +144,7 @@ type EnsureProjectAccessTokenOptions struct {
 	// UID is a unique identifier for the token.
 	// If set, the given UID will be compared with the UID of the existing token.
 	// The token will be force updated if the UIDs do not match.
-	UID string
+	UID *string
 }
 
 type ProjectAccessToken struct {


### PR DESCRIPTION
Fixes an issue on initial token create if someone already manually added a token.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
