### PR TITLE
Format `CLUSTERS` variable according to SDD.

### DIFF
--- a/controllers/tenant_compile_pipeline_controller.go
+++ b/controllers/tenant_compile_pipeline_controller.go
@@ -102,7 +102,7 @@ func (r *TenantCompilePipelineReconciler) ensureCiVariables(t *synv1alpha1.Tenan
 	if pipelineStatus == nil {
 		pipelineStatus = &synv1alpha1.CompilePipelineStatus{}
 	}
-	clusterList := strings.Join(pipelineStatus.Clusters, ",")
+	clusterList := strings.Join(pipelineStatus.Clusters, " ")
 
 	list, ch := updateEnvVarValue(CI_VARIABLE_API_URL, r.ApiUrl, template.CIVariables)
 	changed = ch

--- a/controllers/tenant_compile_pipeline_controller_test.go
+++ b/controllers/tenant_compile_pipeline_controller_test.go
@@ -52,7 +52,7 @@ func Test_AddBasicPipelineStatus(t *testing.T) {
 	assert.Equal(t, "token", mod_tenant.GetGitTemplate().CIVariables[i].ValueFrom.SecretKeyRef.Key)
 	i = envVarIndex("CLUSTERS", &mod_tenant.GetGitTemplate().CIVariables)
 	assert.True(t, i >= 0)
-	assert.Equal(t, "c-cluster1,c-cluster2", mod_tenant.GetGitTemplate().CIVariables[i].Value)
+	assert.Equal(t, "c-cluster1 c-cluster2", mod_tenant.GetGitTemplate().CIVariables[i].Value)
 }
 func Test_RemoveBasicPipelineStatus(t *testing.T) {
 	tenant := &synv1alpha1.Tenant{
@@ -168,7 +168,7 @@ func Test_UpdateBasicPipelineStatus(t *testing.T) {
 	assert.Equal(t, "token", mod_tenant.GetGitTemplate().CIVariables[i].ValueFrom.SecretKeyRef.Key)
 	i = envVarIndex("CLUSTERS", &mod_tenant.GetGitTemplate().CIVariables)
 	assert.True(t, i >= 0)
-	assert.Equal(t, "c-cluster1,c-cluster2", mod_tenant.GetGitTemplate().CIVariables[i].Value)
+	assert.Equal(t, "c-cluster1 c-cluster2", mod_tenant.GetGitTemplate().CIVariables[i].Value)
 }
 
 func Test_UpdateBasicPipelineStatus_NoUpdate_IfNoChanges(t *testing.T) {
@@ -200,7 +200,7 @@ func Test_UpdateBasicPipelineStatus_NoUpdate_IfNoChanges(t *testing.T) {
 					},
 					{
 						Name:  "CLUSTERS",
-						Value: "c-cluster1,c-cluster2",
+						Value: "c-cluster1 c-cluster2",
 					},
 				},
 			},


### PR DESCRIPTION
Replaces separator `,` by space (` `).

https://syn.tools/syn/SDDs/0032-compile-pipeline.html

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
