### PR TITLE
Sort cluster names in permissions to remove unnecessary updated

### DIFF
--- a/controllers/tenant/role.go
+++ b/controllers/tenant/role.go
@@ -2,6 +2,7 @@ package tenant
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/projectsyn/lieutenant-operator/api/v1alpha1"
 	synv1alpha1 "github.com/projectsyn/lieutenant-operator/api/v1alpha1"
@@ -29,6 +30,7 @@ func reconcileRole(obj pipeline.Object, data *pipeline.Context) pipeline.Result 
 	for _, c := range cls.Items {
 		clusterNames = append(clusterNames, c.Name)
 	}
+	slices.Sort(clusterNames)
 
 	role := rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This is now an issue with the compile pipelines which changes clusters more often.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
