### PR TITLE
Prevent the operator from removing the git repo url on transient Gitlab errors

### DIFF
--- a/controllers/gitrepo/steps_test.go
+++ b/controllers/gitrepo/steps_test.go
@@ -563,7 +563,7 @@ func (r *fakeRepo) Update() (bool, error) {
 }
 func (r fakeRepo) Read() error {
 	if !r.exists {
-		return errors.New("Repos does not exist")
+		return manager.ErrRepoNotFound
 	}
 	return nil
 }

--- a/git/gitlab/gitlab.go
+++ b/git/gitlab/gitlab.go
@@ -206,6 +206,9 @@ func (g *Gitlab) delete() error {
 func (g *Gitlab) getProject() error {
 	project, _, err := g.client.Projects.GetProject(g.ops.Path+"/"+g.ops.RepoName, &gitlab.GetProjectOptions{})
 	if err != nil {
+		if errors.Is(err, gitlab.ErrNotFound) {
+			return manager.ErrRepoNotFound
+		}
 		return err
 	}
 

--- a/git/gitlab/gitlab_test.go
+++ b/git/gitlab/gitlab_test.go
@@ -48,14 +48,14 @@ func TestGitlab_Read(t *testing.T) {
 		name       string
 		fields     fields
 		httpServer *httptest.Server
-		wantErr    bool
+		wantErrIs  error
 	}{
 		{
 			name: "test read ok",
 			fields: fields{
 				credentials: manager.Credentials{},
 			},
-			wantErr:    false,
+			wantErrIs:  nil,
 			httpServer: testGetHTTPServer(http.StatusOK, []byte(`{"id":3,"description":null,"default_branch":"master","visibility":"private","ssh_url_to_repo":"git@example.com:diaspora/diaspora-project-site.git","http_url_to_repo":"http://example.com/diaspora/diaspora-project-site.git","web_url":"http://example.com/diaspora/diaspora-project-site","readme_url":"http://example.com/diaspora/diaspora-project-site/blob/master/README.md","tag_list":["example","disapora project"],"owner":{"id":3,"name":"Diaspora","created_at":"2013-09-30T13:46:02Z"},"name":"Diaspora Project Site","name_with_namespace":"Diaspora / Diaspora Project Site","path":"diaspora-project-site","path_with_namespace":"diaspora/diaspora-project-site","issues_enabled":true,"open_issues_count":1,"merge_requests_enabled":true,"jobs_enabled":true,"wiki_enabled":true,"snippets_enabled":false,"resolve_outdated_diff_discussions":false,"container_registry_enabled":false,"container_expiration_policy":{"cadence":"7d","enabled":false,"keep_n":null,"older_than":null,"name_regex":null,"next_run_at":"2020-01-07T21:42:58.658Z"},"created_at":"2013-09-30T13:46:02Z","last_activity_at":"2013-09-30T13:46:02Z","creator_id":3,"namespace":{"id":3,"name":"Diaspora","path":"diaspora","kind":"group","full_path":"diaspora","avatar_url":"http://localhost:3000/uploads/group/avatar/3/foo.jpg","web_url":"http://localhost:3000/groups/diaspora"},"import_status":"none","import_error":null,"permissions":{"project_access":{"access_level":10,"notification_level":3},"group_access":{"access_level":50,"notification_level":3}},"archived":false,"avatar_url":"http://example.com/uploads/project/avatar/3/uploads/avatar.png","license_url":"http://example.com/diaspora/diaspora-client/blob/master/LICENSE","license":{"key":"lgpl-3.0","name":"GNU Lesser General Public License v3.0","nickname":"GNU LGPLv3","html_url":"http://choosealicense.com/licenses/lgpl-3.0/","source_url":"http://www.gnu.org/licenses/lgpl-3.0.txt"},"shared_runners_enabled":true,"forks_count":0,"star_count":0,"runners_token":"b8bc4a7a29eb76ea83cf79e4908c2b","ci_default_git_depth":50,"public_jobs":true,"shared_with_groups":[{"group_id":4,"group_name":"Twitter","group_full_path":"twitter","group_access_level":30},{"group_id":3,"group_name":"Gitlab Org","group_full_path":"gitlab-org","group_access_level":10}],"repository_storage":"default","only_allow_merge_if_pipeline_succeeds":false,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":false,"printing_merge_requests_link_enabled":true,"request_access_enabled":false,"merge_method":"merge","auto_devops_enabled":true,"auto_devops_deploy_strategy":"continuous","approvals_before_merge":0,"mirror":false,"mirror_user_id":45,"mirror_trigger_builds":false,"only_mirror_protected_branches":false,"mirror_overwrites_diverged_branches":false,"external_authorization_classification_label":null,"packages_enabled":true,"service_desk_enabled":false,"service_desk_address":null,"autoclose_referenced_issues":true,"suggestion_commit_message":null,"statistics":{"commit_count":37,"storage_size":1038090,"repository_size":1038090,"wiki_size":0,"lfs_objects_size":0,"job_artifacts_size":0,"packages_size":0},"_links":{"self":"http://example.com/api/v4/projects","issues":"http://example.com/api/v4/projects/1/issues","merge_requests":"http://example.com/api/v4/projects/1/merge_requests","repo_branches":"http://example.com/api/v4/projects/1/repository_branches","labels":"http://example.com/api/v4/projects/1/labels","events":"http://example.com/api/v4/projects/1/events","members":"http://example.com/api/v4/projects/1/members"}}`)),
 		},
 		{
@@ -63,7 +63,7 @@ func TestGitlab_Read(t *testing.T) {
 			fields: fields{
 				credentials: manager.Credentials{},
 			},
-			wantErr:    true,
+			wantErrIs:  manager.ErrRepoNotFound,
 			httpServer: testGetHTTPServer(http.StatusNotFound, []byte(`{"error":"not found"}`)),
 		},
 	}
@@ -84,9 +84,7 @@ func TestGitlab_Read(t *testing.T) {
 			err := g.Connect()
 			require.NoError(t, err)
 
-			if err := g.Read(); (err != nil) != tt.wantErr {
-				t.Errorf("Read() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			require.ErrorIs(t, g.Read(), tt.wantErrIs)
 		})
 	}
 }

--- a/git/manager/manager.go
+++ b/git/manager/manager.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -92,6 +93,9 @@ type Credentials struct {
 	Token string
 }
 
+// ErrRepoNotFound is returned when a repository is not found
+var ErrRepoNotFound = errors.New("repository not found")
+
 // Repo represents a repository that lives on some git server
 type Repo interface {
 	// Type returns the type of the repo
@@ -102,8 +106,8 @@ type Repo interface {
 	// Update will enforce the defined keys to be deployed to the repository, it will return true if an actual change
 	// happened
 	Update() (bool, error)
-	// Read will read the repository and populate it with the deployed keys. It will throw an
-	// error if the repo is not found on the server.
+	// Read will read the repository and populate it with the deployed keys.
+	// Implementations MUST return ErrRepoNotFound if the repository does not exist.
 	Read() error
 	// Remove will remove the git project according to the recycle policy
 	Remove() error


### PR DESCRIPTION
`repoExists()` returned false for every error, not only `ErrNotFound`. If `repo.Create` then also returned an error - which is highly likely because the repo already exists or the transient error still persists - the repo url would be deleted.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
