### PR TITLE
Fix duplicate controller name `tenant`

### DIFF
--- a/controllers/tenant_compile_pipeline_controller.go
+++ b/controllers/tenant_compile_pipeline_controller.go
@@ -169,6 +169,7 @@ func (r *TenantCompilePipelineReconciler) ensureCiVariables(t *synv1alpha1.Tenan
 // SetupWithManager sets up the controller with the Manager.
 func (r *TenantCompilePipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("tenant_compile_pipeline").
 		For(&synv1alpha1.Tenant{}).
 		Owns(&synv1alpha1.Cluster{}).
 		Complete(r)


### PR DESCRIPTION
Now validated by updated controller-runtime.

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
