### PR TITLE
Stop logging full access token secret

### DIFF
--- a/controllers/gitrepo/steps.go
+++ b/controllers/gitrepo/steps.go
@@ -189,7 +189,11 @@ func ensureAccessToken(ctx context.Context, cli client.Client, instance *synv1al
 	if err != nil {
 		return fmt.Errorf("error creating or updating access token secret: %w", err)
 	}
-	log.FromContext(ctx).Info("Reconciled secret", "secret", secret, "op", op)
+	log.FromContext(ctx).Info("Reconciled secret",
+		"secret", secret.Name,
+		"pat_uid", secret.Annotations[LieutenantAccessTokenUIDAnnotation],
+		"pat_expires_at", secret.Annotations[LieutenantAccessTokenExpiresAtAnnotation],
+		"op", op)
 
 	return nil
 }


### PR DESCRIPTION
Note that the log was truncated before any token was exposed.


## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog