### PR TITLE
Introduce new metric `syn_cluster_dynamic_facts`

### DIFF
--- a/metrics/cluster_info_collector.go
+++ b/metrics/cluster_info_collector.go
@@ -31,11 +31,28 @@ var clusterFactsDesc = prometheus.NewDesc(
 	nil,
 )
 
-// commodore build info has dynamic labels
+var clusterDynFactsDesc = prometheus.NewDesc(
+	"syn_lieutenant_cluster_dynamic_facts",
+	"Lieutenant cluster dynamic facts.",
+	[]string{"cluster", "tenant", "display_name"},
+	nil,
+)
+
+// cluster facts has dynamic labels
 func newClusterFactsDesc(lbls ...string) *prometheus.Desc {
 	return prometheus.NewDesc(
 		"syn_lieutenant_cluster_facts",
 		"Lieutenant cluster facts. Keys are normalized to be valid Prometheus labels.",
+		lbls,
+		nil,
+	)
+}
+
+// cluster dynamic facts has dynamic labels
+func newClusterDynFactsDesc(lbls ...string) *prometheus.Desc {
+	return prometheus.NewDesc(
+		"syn_lieutenant_cluster_dynamic_facts",
+		"Lieutenant cluster dynamic facts. Keys are normalized to be valid Prometheus labels.",
 		lbls,
 		nil,
 	)
@@ -73,8 +90,12 @@ func (m *ClusterInfoCollector) Collect(ch chan<- prometheus.Metric) {
 			cl.Name, cl.Spec.TenantRef.Name, cl.Spec.DisplayName,
 		)
 
-		if err := clusterFacts(cl, ch); err != nil {
+		if err := clusterFacts(newClusterFactsDesc, cl, cl.Spec.Facts, ch); err != nil {
 			log.Log.Info("failed to collect cluster facts", "error", err)
+		}
+
+		if err := clusterFacts(newClusterDynFactsDesc, cl, cl.Status.Facts, ch); err != nil {
+			log.Log.Info("failed to collect cluster dynamic facts", "error", err)
 		}
 	}
 }
@@ -85,8 +106,8 @@ func (m *ClusterInfoCollector) Collect(ch chan<- prometheus.Metric) {
 // If a key is empty it is replaced with "_empty".
 // If a key is in the protected list after normalizing it is prefixed with "orig_".
 // If a key is a duplicate after normalizing it is suffixed with "_<n>" where n is the number of duplicates.
-func clusterFacts(cl synv1alpha1.Cluster, ch chan<- prometheus.Metric) error {
-	rks, vs := pairs(cl.Spec.Facts)
+func clusterFacts(descfn func(lbls ...string) *prometheus.Desc, cl synv1alpha1.Cluster, facts synv1alpha1.Facts, ch chan<- prometheus.Metric) error {
+	rks, vs := pairs(facts)
 	ks := make([]string, len(rks))
 	for i, k := range rks {
 		ks[i] = normalizeLabelKey(k, []string{"cluster", "tenant"}, "fact_")
@@ -100,7 +121,7 @@ func clusterFacts(cl synv1alpha1.Cluster, ch chan<- prometheus.Metric) error {
 	}
 
 	m, err := prometheus.NewConstMetric(
-		newClusterFactsDesc(append([]string{"cluster", "tenant"}, ks...)...),
+		descfn(append([]string{"cluster", "tenant"}, ks...)...),
 		prometheus.GaugeValue,
 		1,
 		append([]string{cl.Name, cl.Spec.TenantRef.Name}, vs...)...,

--- a/metrics/cluster_info_collector_test.go
+++ b/metrics/cluster_info_collector_test.go
@@ -19,6 +19,7 @@ func Test_ClusterInfoCollector(t *testing.T) {
 	expectedMetricNames := []string{
 		"syn_lieutenant_cluster_info",
 		"syn_lieutenant_cluster_facts",
+		"syn_lieutenant_cluster_dynamic_facts",
 	}
 
 	c := prepareClient(t,
@@ -49,6 +50,11 @@ func Test_ClusterInfoCollector(t *testing.T) {
 					"tenant":                         "value",
 				},
 			},
+			Status: synv1alpha1.ClusterStatus{
+				Facts: map[string]string{
+					"test": "value",
+				},
+			},
 		},
 	)
 
@@ -58,7 +64,11 @@ func Test_ClusterInfoCollector(t *testing.T) {
 		Namespace: namespace,
 	}
 
-	metrics := `# HELP syn_lieutenant_cluster_facts Lieutenant cluster facts. Keys are normalized to be valid Prometheus labels.
+	metrics := `# HELP syn_lieutenant_cluster_dynamic_facts Lieutenant cluster dynamic facts. Keys are normalized to be valid Prometheus labels.
+# TYPE syn_lieutenant_cluster_dynamic_facts gauge
+syn_lieutenant_cluster_dynamic_facts{cluster="c-empty",tenant=""} 1
+syn_lieutenant_cluster_dynamic_facts{cluster="c2",tenant="t2",test="value"} 1
+# HELP syn_lieutenant_cluster_facts Lieutenant cluster facts. Keys are normalized to be valid Prometheus labels.
 # TYPE syn_lieutenant_cluster_facts gauge
 syn_lieutenant_cluster_facts{cluster="c-empty",tenant=""} 1
 syn_lieutenant_cluster_facts{cluster="c2",fact__key="value",fact__key_duplicate_after_normalize="value",fact__key_duplicate_after_normalize_1="value",fact__key_duplicate_after_normalize_2="value",key="value",key_with847_____invalid_chars="value",orig_cluster="value",orig_tenant="value",tenant="t2"} 1


### PR DESCRIPTION
This metric enables us to easily consume Lieutenant cluster dynamic facts through Prometheus queries (e.g. for central dashboards).

We currently don't filter out any dynamic facts, and accept that the metric may have sizeable label values.

Generally speaking, Prometheus should be able to handle bigger label values gracefully, but if the larger label values (currently primarily `status.facts.kubernetesVersion`) turn out to be an issue, we can always drop them with a scrape relabel config (in the `ServiceMonitor` for each Lieutenant instance).

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
